### PR TITLE
Feature/dql 25 data qld enhancements combined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,45 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 
+.ropeproject
+node_modules
+bower_components
 
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+sdist/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Sphinx documentation
+docs/_build/

--- a/ckanext/ytp/comments/bad_words.txt
+++ b/ckanext/ytp/comments/bad_words.txt
@@ -1,0 +1,1693 @@
+2 girls 1 cup
+2g1c
+4r5e
+5h1t
+5hit
+a$$
+a$$hole
+a_s_s
+a2m
+a54
+a55
+a55hole
+acrotomophilia
+aeolus
+ahole
+alabama hot pocket
+alaskan pipeline
+anal
+anal impaler
+anal leakage
+analprobe
+anilingus
+anus
+apeshit
+ar5e
+areola
+areole
+arian
+arrse
+arse
+arsehole
+aryan
+ass
+ass fuck
+ass fuck
+ass hole
+assbag
+assbandit
+assbang
+assbanged
+assbanger
+assbangs
+assbite
+assclown
+asscock
+asscracker
+asses
+assface
+assfaces
+assfuck
+assfucker
+ass-fucker
+assfukka
+assgoblin
+assh0le
+asshat
+ass-hat
+asshead
+assho1e
+asshole
+assholes
+asshopper
+ass-jabber
+assjacker
+asslick
+asslicker
+assmaster
+assmonkey
+assmucus
+assmucus
+assmunch
+assmuncher
+assnigger
+asspirate
+ass-pirate
+assshit
+assshole
+asssucker
+asswad
+asswhole
+asswipe
+asswipes
+auto erotic
+autoerotic
+axwound
+azazel
+azz
+b!tch
+b00bs
+b17ch
+b1tch
+babeland
+baby batter
+baby juice
+ball gag
+ball gravy
+ball kicking
+ball licking
+ball sack
+ball sucking
+ballbag
+balls
+ballsack
+bampot
+bang (one's) box
+bangbros
+bareback
+barely legal
+barenaked
+barf
+bastard
+bastardo
+bastards
+bastinado
+batty boy
+bawdy
+bbw
+bdsm
+beaner
+beaners
+beardedclam
+beastial
+beastiality
+beatch
+beaver
+beaver cleaver
+beaver lips
+beef curtain
+beef curtain
+beef curtains
+beeyotch
+bellend
+bender
+beotch
+bescumber
+bestial
+bestiality
+bi+ch
+biatch
+big black
+big breasts
+big knockers
+big tits
+bigtits
+bimbo
+bimbos
+bint
+birdlock
+bitch
+bitch tit
+bitch tit
+bitchass
+bitched
+bitcher
+bitchers
+bitches
+bitchin
+bitching
+bitchtits
+bitchy
+black cock
+blonde action
+blonde on blonde action
+bloodclaat
+bloody
+bloody hell
+blow job
+blow me
+blow mud
+blow your load
+blowjob
+blowjobs
+blue waffle
+blue waffle
+blumpkin
+blumpkin
+bod
+boink
+boiolas
+bollock
+bollocks
+bollok
+bollox
+bondage
+boned
+boner
+boners
+bong
+boob
+boobies
+boobs
+booby
+booger
+bookie
+boong
+booobs
+boooobs
+booooobs
+booooooobs
+bootee
+bootie
+booty
+booty call
+booze
+boozer
+boozy
+bosom
+bosomy
+breasts
+Breeder
+brotherfucker
+brown showers
+brunette action
+buceta
+bugger
+bukkake
+bull shit
+bulldyke
+bullet vibe
+bullshit
+bullshits
+bullshitted
+bullturds
+bum
+bum boy
+bumblefuck
+bumclat
+bummer
+buncombe
+bung
+bung hole
+bunghole
+bunny fucker
+bust a load
+bust a load
+busty
+butt
+butt fuck
+butt fuck
+butt plug
+buttcheeks
+buttfuck
+buttfucka
+buttfucker
+butthole
+buttmuch
+buttmunch
+butt-pirate
+buttplug
+c.0.c.k
+c.o.c.k.
+c.u.n.t
+c0ck
+c-0-c-k
+c0cksucker
+caca
+cacafuego
+cahone
+camel toe
+cameltoe
+camgirl
+camslut
+camwhore
+carpet muncher
+carpetmuncher
+cawk
+cervix
+chesticle
+chi-chi man
+chick with a dick
+child-fucker
+chinc
+chincs
+chink
+chinky
+choad
+choade
+choade
+choc ice
+chocolate rosebuds
+chode
+chodes
+chota bags
+chota bags
+cipa
+circlejerk
+cl1t
+cleveland steamer
+climax
+clit
+clit licker
+clit licker
+clitface
+clitfuck
+clitoris
+clitorus
+clits
+clitty
+clitty litter
+clitty litter
+clover clamps
+clunge
+clusterfuck
+cnut
+cocain
+cocaine
+coccydynia
+cock
+c-o-c-k
+cock pocket
+cock pocket
+cock snot
+cock snot
+cock sucker
+cockass
+cockbite
+cockblock
+cockburger
+cockeye
+cockface
+cockfucker
+cockhead
+cockholster
+cockjockey
+cockknocker
+cockknoker
+Cocklump
+cockmaster
+cockmongler
+cockmongruel
+cockmonkey
+cockmunch
+cockmuncher
+cocknose
+cocknugget
+cocks
+cockshit
+cocksmith
+cocksmoke
+cocksmoker
+cocksniffer
+cocksuck
+cocksuck
+cocksucked
+cocksucked
+cocksucker
+cock-sucker
+cocksuckers
+cocksucking
+cocksucks
+cocksucks
+cocksuka
+cocksukka
+cockwaffle
+coffin dodger
+coital
+cok
+cokmuncher
+coksucka
+commie
+condom
+coochie
+coochy
+coon
+coonnass
+coons
+cooter
+cop some wood
+cop some wood
+coprolagnia
+coprophilia
+corksucker
+cornhole
+cornhole
+corp whore
+corp whore
+corpulent
+cox
+crabs
+crack
+cracker
+crackwhore
+crap
+crappy
+creampie
+cretin
+crikey
+cripple
+crotte
+cum
+cum chugger
+cum chugger
+cum dumpster
+cum dumpster
+cum freak
+cum freak
+cum guzzler
+cum guzzler
+cumbubble
+cumdump
+cumdump
+cumdumpster
+cumguzzler
+cumjockey
+cummer
+cummin
+cumming
+cums
+cumshot
+cumshots
+cumslut
+cumstain
+cumtart
+cunilingus
+cunillingus
+cunnie
+cunnilingus
+cunny
+cunt
+c-u-n-t
+cunt hair
+cunt hair
+cuntass
+cuntbag
+cuntbag
+cuntface
+cunthole
+cunthunter
+cuntlick
+cuntlick
+cuntlicker
+cuntlicker
+cuntlicking
+cuntlicking
+cuntrag
+cunts
+cuntsicle
+cuntsicle
+cuntslut
+cunt-struck
+cunt-struck
+cus
+cut rope
+cut rope
+cyalis
+cyberfuc
+cyberfuck
+cyberfuck
+cyberfucked
+cyberfucked
+cyberfucker
+cyberfuckers
+cyberfucking
+cyberfucking
+d0ng
+d0uch3
+d0uche
+d1ck
+d1ld0
+d1ldo
+dago
+dagos
+dammit
+damn
+damned
+damnit
+darkie
+darn
+date rape
+daterape
+dawgie-style
+deep throat
+deepthroat
+deggo
+dendrophilia
+dick
+dick head
+dick hole
+dick hole
+dick shy
+dick shy
+dickbag
+dickbeaters
+dickdipper
+dickface
+dickflipper
+dickfuck
+dickfucker
+dickhead
+dickheads
+dickhole
+dickish
+dick-ish
+dickjuice
+dickmilk
+dickmonger
+dickripper
+dicks
+dicksipper
+dickslap
+dick-sneeze
+dicksucker
+dicksucking
+dicktickler
+dickwad
+dickweasel
+dickweed
+dickwhipper
+dickwod
+dickzipper
+diddle
+dike
+dildo
+dildos
+diligaf
+dillweed
+dimwit
+dingle
+dingleberries
+dingleberry
+dink
+dinks
+dipship
+dipshit
+dirsa
+dirty
+dirty pillows
+dirty sanchez
+dirty Sanchez
+div
+dlck
+dog style
+dog-fucker
+doggie style
+doggiestyle
+doggie-style
+doggin
+dogging
+doggy style
+doggystyle
+doggy-style
+dolcett
+domination
+dominatrix
+dommes
+dong
+donkey punch
+donkeypunch
+donkeyribber
+doochbag
+doofus
+dookie
+doosh
+dopey
+double dong
+double penetration
+Doublelift
+douch3
+douche
+douchebag
+douchebags
+douche-fag
+douchewaffle
+douchey
+dp action
+drunk
+dry hump
+duche
+dumass
+dumb ass
+dumbass
+dumbasses
+Dumbcunt
+dumbfuck
+dumbshit
+dummy
+dumshit
+dvda
+dyke
+dykes
+eat a dick
+eat a dick
+eat hair pie
+eat hair pie
+eat my ass
+ecchi
+ejaculate
+ejaculated
+ejaculates
+ejaculates
+ejaculating
+ejaculating
+ejaculatings
+ejaculation
+ejakulate
+erect
+erection
+erotic
+erotism
+escort
+essohbee
+eunuch
+extacy
+extasy
+f u c k
+f u c k e r
+f.u.c.k
+f_u_c_k
+f4nny
+facial
+fack
+fag
+fagbag
+fagfucker
+fagg
+fagged
+fagging
+faggit
+faggitt
+faggot
+faggotcock
+faggots
+faggs
+fagot
+fagots
+fags
+fagtard
+faig
+faigt
+fanny
+fannybandit
+fannyflaps
+fannyfucker
+fanyy
+fark
+farker
+fart
+fartknocker
+fatass
+fcuk
+fcuker
+fcuking
+fecal
+feck
+fecker
+feist
+felch
+felcher
+felching
+fellate
+fellatio
+feltch
+feltcher
+female squirting
+femdom
+fenian
+fice
+figging
+fingerbang
+fingerfuck
+fingerfuck
+fingerfucked
+fingerfucked
+fingerfucker
+fingerfucker
+fingerfuckers
+fingerfucking
+fingerfucking
+fingerfucks
+fingerfucks
+fingering
+fist fuck
+fist fuck
+fisted
+fistfuck
+fistfucked
+fistfucked
+fistfucker
+fistfucker
+fistfuckers
+fistfuckers
+fistfucking
+fistfucking
+fistfuckings
+fistfuckings
+fistfucks
+fistfucks
+fisting
+fisty
+flamer
+flange
+flaps
+fleshflute
+flog the log
+flog the log
+floozy
+foad
+foah
+fondle
+foobar
+fook
+fooker
+foot fetish
+footjob
+foreskin
+freex
+frenchify
+frigg
+frigga
+frotting
+fubar
+fuc
+fuck
+fuck
+f-u-c-k
+fuck buttons
+fuck hole
+fuck hole
+Fuck off
+fuck puppet
+fuck puppet
+fuck trophy
+fuck trophy
+fuck yo mama
+fuck yo mama
+fuck you
+fucka
+fuckass
+fuck-ass
+fuck-ass
+fuckbag
+fuck-bitch
+fuck-bitch
+fuckboy
+fuckbrain
+fuckbutt
+fuckbutter
+fucked
+fuckedup
+fucker
+fuckers
+fuckersucker
+fuckface
+fuckhead
+fuckheads
+fuckhole
+fuckin
+fucking
+fuckings
+fuckingshitmotherfucker
+fuckme
+fuckme
+fuckmeat
+fuckmeat
+fucknugget
+fucknut
+fucknutt
+fuckoff
+fucks
+fuckstick
+fucktard
+fuck-tard
+fucktards
+fucktart
+fucktoy
+fucktoy
+fucktwat
+fuckup
+fuckwad
+fuckwhit
+fuckwit
+fuckwitt
+fudge packer
+fudgepacker
+fudge-packer
+fuk
+fuker
+fukker
+fukkers
+fukkin
+fuks
+fukwhit
+fukwit
+fuq
+futanari
+fux
+fux0r
+fvck
+fxck
+gae
+gai
+gang bang
+gangbang
+gang-bang
+gang-bang
+gangbanged
+gangbangs
+ganja
+gash
+gassy ass
+gassy ass
+gay sex
+gayass
+gaybob
+gaydo
+gayfuck
+gayfuckist
+gaylord
+gays
+gaysex
+gaytard
+gaywad
+gender bender
+genitals
+gey
+gfy
+ghay
+ghey
+giant cock
+gigolo
+gippo
+girl on
+girl on top
+girls gone wild
+git
+glans
+goatcx
+goatse
+god damn
+godamn
+godamnit
+goddam
+god-dam
+goddammit
+goddamn
+goddamned
+god-damned
+goddamnit
+godsdamn
+gokkun
+golden shower
+goldenshower
+golliwog
+gonad
+gonads
+goo girl
+gooch
+goodpoop
+gook
+gooks
+goregasm
+gringo
+grope
+group sex
+gspot
+g-spot
+gtfo
+guido
+guro
+h0m0
+h0mo
+ham flap
+ham flap
+hand job
+handjob
+hard core
+hard on
+hardcore
+hardcoresex
+he11
+hebe
+heeb
+hell
+hemp
+hentai
+heroin
+herp
+herpes
+herpy
+heshe
+he-she
+hircismus
+hitler
+hiv
+ho
+hoar
+hoare
+hobag
+hoe
+hoer
+holy shit
+hom0
+homey
+homo
+homodumbshit
+homoerotic
+homoey
+honkey
+honky
+hooch
+hookah
+hooker
+hoor
+hootch
+hooter
+hooters
+hore
+horniest
+horny
+hot carl
+hot chick
+hotsex
+how to kill
+how to murdep
+how to murder
+huge fat
+hump
+humped
+humping
+hun
+hussy
+hymen
+iap
+iberian slap
+inbred
+incest
+injun
+intercourse
+jack off
+jackass
+jackasses
+jackhole
+jackoff
+jack-off
+jaggi
+jagoff
+jail bait
+jailbait
+jap
+japs
+jelly donut
+jerk
+jerk off
+jerk0ff
+jerkass
+jerked
+jerkoff
+jerk-off
+jigaboo
+jiggaboo
+jiggerboo
+jism
+jiz
+jiz
+jizm
+jizm
+jizz
+jizzed
+jock
+juggs
+jungle bunny
+junglebunny
+junkie
+junky
+kafir
+kawk
+kike
+kikes
+kill
+kinbaku
+kinkster
+kinky
+klan
+knob
+knob end
+knobbing
+knobead
+knobed
+knobend
+knobhead
+knobjocky
+knobjokey
+kock
+kondum
+kondums
+kooch
+kooches
+kootch
+kraut
+kum
+kummer
+kumming
+kums
+kunilingus
+kunja
+kunt
+kwif
+kwif
+kyke
+l3i+ch
+l3itch
+labia
+lameass
+lardass
+leather restraint
+leather straight jacket
+lech
+lemon party
+LEN
+leper
+lesbian
+lesbians
+lesbo
+lesbos
+lez
+lezza/lesbo
+lezzie
+lmao
+lmfao
+loin
+loins
+lolita
+looney
+lovemaking
+lube
+lust
+lusting
+lusty
+m0f0
+m0fo
+m45terbate
+ma5terb8
+ma5terbate
+mafugly
+mafugly
+make me come
+male squirting
+mams
+masochist
+massa
+masterb8
+masterbat*
+masterbat3
+masterbate
+master-bate
+master-bate
+masterbating
+masterbation
+masterbations
+masturbate
+masturbating
+masturbation
+maxi
+mcfagget
+menage a trois
+menses
+menstruate
+menstruation
+meth
+m-fucking
+microphallus
+middle finger
+midget
+milf
+minge
+minger
+missionary position
+mof0
+mofo
+mo-fo
+molest
+mong
+moo moo foo foo
+moolie
+moron
+mothafuck
+mothafucka
+mothafuckas
+mothafuckaz
+mothafucked
+mothafucked
+mothafucker
+mothafuckers
+mothafuckin
+mothafucking
+mothafucking
+mothafuckings
+mothafucks
+mother fucker
+mother fucker
+motherfuck
+motherfucka
+motherfucked
+motherfucker
+motherfuckers
+motherfuckin
+motherfucking
+motherfuckings
+motherfuckka
+motherfucks
+mound of venus
+mr hands
+muff
+muff diver
+muff puff
+muff puff
+muffdiver
+muffdiving
+munging
+munter
+murder
+mutha
+muthafecker
+muthafuckker
+muther
+mutherfucker
+n1gga
+n1gger
+naked
+nambla
+napalm
+nappy
+nawashi
+nazi
+nazism
+need the dick
+need the dick
+negro
+neonazi
+nig nog
+nigaboo
+nigg3r
+nigg4h
+nigga
+niggah
+niggas
+niggaz
+nigger
+niggers
+niggle
+niglet
+nig-nog
+nimphomania
+nimrod
+ninny
+ninnyhammer
+nipple
+nipples
+nob
+nob jokey
+nobhead
+nobjocky
+nobjokey
+nonce
+nsfw images
+nude
+nudity
+numbnuts
+nut butter
+nut butter
+nut sack
+nutsack
+nutter
+nympho
+nymphomania
+octopussy
+old bag
+omg
+omorashi
+one cup two girls
+one guy one jar
+opiate
+opium
+orally
+organ
+orgasim
+orgasims
+orgasm
+orgasmic
+orgasms
+orgies
+orgy
+ovary
+ovum
+ovums
+p.u.s.s.y.
+p0rn
+paedophile
+paki
+panooch
+pansy
+pantie
+panties
+panty
+pcp
+pecker
+peckerhead
+pedo
+pedobear
+pedophile
+pedophilia
+pedophiliac
+pee
+peepee
+pegging
+penetrate
+penetration
+penial
+penile
+penis
+penisbanger
+penisfucker
+penispuffer
+perversion
+phallic
+phone sex
+phonesex
+phuck
+phuk
+phuked
+phuking
+phukked
+phukking
+phuks
+phuq
+piece of shit
+pigfucker
+pikey
+pillowbiter
+pimp
+pimpis
+pinko
+piss
+piss off
+piss pig
+pissed
+pissed off
+pisser
+pissers
+pisses
+pisses
+pissflaps
+pissin
+pissin
+pissing
+pissoff
+pissoff
+piss-off
+pisspig
+playboy
+pleasure chest
+pms
+polack
+pole smoker
+polesmoker
+pollock
+ponyplay
+poof
+poon
+poonani
+poonany
+poontang
+poop
+poop chute
+poopchute
+Poopuncher
+porch monkey
+porchmonkey
+porn
+porno
+pornography
+pornos
+potty
+prick
+pricks
+prickteaser
+prig
+prince albert piercing
+pron
+prostitute
+prude
+psycho
+pthc
+pube
+pubes
+pubic
+pubis
+punani
+punanny
+punany
+punkass
+punky
+punta
+puss
+pusse
+pussi
+pussies
+pussy
+pussy fart
+pussy fart
+pussy palace
+pussy palace
+pussylicking
+pussypounder
+pussys
+pust
+puto
+queaf
+queaf
+queef
+queer
+queerbait
+queerhole
+queero
+queers
+quicky
+quim
+racy
+raghead
+raging boner
+rape
+raped
+raper
+rapey
+raping
+rapist
+raunch
+rectal
+rectum
+rectus
+reefer
+reetard
+reich
+renob
+retard
+retarded
+reverse cowgirl
+revue
+rimjaw
+rimjob
+rimming
+ritard
+rosy palm
+rosy palm and her 5 sisters
+rtard
+r-tard
+rum
+rump
+rumprammer
+ruski
+rusty trombone
+s hit
+s&m
+s.h.i.t.
+s.o.b.
+s_h_i_t
+s0b
+sadism
+sadist
+sambo
+sand nigger
+sandbar
+sandbar
+Sandler
+sandnigger
+sanger
+santorum
+sausage queen
+sausage queen
+scag
+scantily
+scat
+schizo
+schlong
+scissoring
+screw
+screwed
+screwing
+scroat
+scrog
+scrot
+scrote
+scrotum
+scrud
+scum
+seaman
+seamen
+seduce
+seks
+semen
+sex
+sexo
+sexual
+sexy
+sh!+
+sh!t
+sh1t
+s-h-1-t
+shag
+shagger
+shaggin
+shagging
+shamedame
+shaved beaver
+shaved pussy
+shemale
+shi+
+shibari
+shirt lifter
+shit
+s-h-i-t
+shit ass
+shit fucker
+shit fucker
+shitass
+shitbag
+shitbagger
+shitblimp
+shitbrains
+shitbreath
+shitcanned
+shitcunt
+shitdick
+shite
+shiteater
+shited
+shitey
+shitface
+shitfaced
+shitfuck
+shitfull
+shithead
+shitheads
+shithole
+shithouse
+shiting
+shitings
+shits
+shitspitter
+shitstain
+shitt
+shitted
+shitter
+shitters
+shitters
+shittier
+shittiest
+shitting
+shittings
+shitty
+shiz
+shiznit
+shota
+shrimping
+sissy
+skag
+skank
+skeet
+skullfuck
+slag
+slanteye
+sleaze
+sleazy
+slope
+slut
+slut bucket
+slut bucket
+slutbag
+slutdumper
+slutkiss
+sluts
+smartass
+smartasses
+smeg
+smegma
+smut
+smutty
+snatch
+sniper
+snowballing
+snuff
+s-o-b
+sod off
+sodom
+sodomize
+sodomy
+son of a bitch
+son of a motherless goat
+son of a whore
+son-of-a-bitch
+souse
+soused
+spac
+spade
+sperm
+spic
+spick
+spik
+spiks
+splooge
+splooge moose
+spooge
+spook
+spread legs
+spunk
+stfu
+stiffy
+stoned
+strap on
+strapon
+strappado
+strip
+strip club
+stroke
+stupid
+style doggy
+suck
+suckass
+sucked
+sucking
+sucks
+suicide girls
+sultry women
+sumofabiatch
+swastika
+swinger
+t1t
+t1tt1e5
+t1tties
+taff
+taig
+tainted love
+taking the piss
+tampon
+tard
+tart
+taste my
+tawdry
+tea bagging
+teabagging
+teat
+teets
+teez
+teste
+testee
+testes
+testical
+testicle
+testis
+threesome
+throating
+thrust
+thug
+thundercunt
+tied up
+tight white
+tinkle
+tit
+tit wank
+tit wank
+titfuck
+titi
+tities
+tits
+titt
+tittie5
+tittiefucker
+titties
+titty
+tittyfuck
+tittyfucker
+tittywank
+titwank
+toke
+tongue in a
+toots
+topless
+tosser
+towelhead
+tramp
+tranny
+transsexual
+trashy
+tribadism
+trumped
+tub girl
+tubgirl
+turd
+tush
+tushy
+tw4t
+twat
+twathead
+twatlips
+twats
+twatty
+twatwaffle
+twink
+twinkie
+two fingers
+two fingers with tongue
+two girls one cup
+twunt
+twunter
+unclefucker
+undies
+undressing
+unwed
+upskirt
+urethra play
+urinal
+urine
+urophilia
+uterus
+uzi
+v14gra
+v1gra
+vag
+vagina
+vajayjay
+va-j-j
+valium
+venus mound
+veqtable
+viagra
+vibrator
+violet wand
+virgin
+vixen
+vjayjay
+vodka
+vomit
+vorarephilia
+voyeur
+vulgar
+vulva
+w00se
+wad
+wang
+wank
+wanker
+wankjob
+wanky
+wazoo
+wedgie
+weed
+weenie
+weewee
+weiner
+weirdo
+wench
+wet dream
+wetback
+wh0re
+wh0reface
+white power
+whiz
+whoar
+whoralicious
+whore
+whorealicious
+whorebag
+whored
+whoreface
+whorehopper
+whorehouse
+whores
+whoring
+wigger
+willies
+willy
+window licker
+wiseass
+wiseasses
+wog
+womb
+wop
+wrapping men
+wrinkled starfish
+wtf
+xrated
+x-rated
+xx
+xxx
+yaoi
+yeasty
+yellow showers
+yid
+yiffy
+yobbo
+zibbi
+zoophilia
+zubb

--- a/ckanext/ytp/comments/bad_words.txt
+++ b/ckanext/ytp/comments/bad_words.txt
@@ -870,7 +870,6 @@ hardcoresex
 he11
 hebe
 heeb
-hell
 hemp
 hentai
 heroin

--- a/ckanext/ytp/comments/controller.py
+++ b/ckanext/ytp/comments/controller.py
@@ -1,5 +1,7 @@
 import ckan.authz as authz
 import logging
+import email_notifications
+import ckan.plugins.toolkit as toolkit
 
 from ckan.lib.base import h, BaseController, render, abort, request
 from ckan import model
@@ -83,7 +85,8 @@ class CommentController(BaseController):
         try:
             c.pkg_dict = get_action('package_show')(context, {'id': dataset_id, 'include_tracking': True})
             c.pkg = context['package']
-        except:
+        except Exception, e:
+            log.debug(e)
             abort(403)
 
         if request.method == 'POST':
@@ -107,6 +110,17 @@ class CommentController(BaseController):
                 abort(403)
 
             if success:
+                email_notifications. notify_admins_and_commenters(
+                    c.pkg.owner_org,
+                    toolkit.c.userobj,
+                    '/templates/email/notification-new-comment.txt',
+                    'Queensland Government open data portal - New comment',
+                    'dataset' if not vars().has_key('content_type') else content_type,
+                    c.pkg.name,
+                    data_dict['url'],
+                    res['id']
+                )
+
                 h.redirect_to(str('/dataset/%s#comment_%s' % (c.pkg.name, res['id'])))
             else:
                 h.redirect_to(str('/dataset/%s#comment_form' % c.pkg.name))

--- a/ckanext/ytp/comments/controller.py
+++ b/ckanext/ytp/comments/controller.py
@@ -2,11 +2,12 @@ import ckan.authz as authz
 import logging
 import email_notifications
 import ckan.plugins.toolkit as toolkit
+import model as comment_model
 import helpers
 
 from ckan.lib.base import h, BaseController, render, abort, request
 from ckan import model
-from ckan.common import c, _
+from ckan.common import c, _, config
 from ckan.logic import check_access, get_action, clean_dict, tuplize_dict, ValidationError, parse_params
 from ckan.lib.navl.dictization_functions import unflatten
 
@@ -16,7 +17,7 @@ log = logging.getLogger(__name__)
 
 class CommentController(BaseController):
     def add(self, dataset_id, content_type='dataset'):
-        return self._add_or_reply(dataset_id, content_type)
+        return self._add_or_reply('new', dataset_id, content_type)
 
     def edit(self, content_type, content_item_id, comment_id):
 
@@ -58,16 +59,10 @@ class CommentController(BaseController):
                     content_item_id if content_type == 'datarequest' else c.pkg.name,
                     'comment_' + str(comment_id) if success else 'edit_' + str(comment_id)
                 ))
-            # if success:
-            #     h.redirect_to(str('/dataset/%s#comment_%s' % (c.pkg.name, res['id'])))
-            # else:
-            #     # @todo check content_type for return URL
-            #     print(content_type)
-            #     h.redirect_to(str('/dataset/%s#edit_%s' % (c.pkg.name, comment_id)))
 
         return helpers.render_content_template(content_type)
 
-    def reply(self, dataset_id, parent_id):
+    def reply(self, content_type, dataset_id, parent_id):
         c.action = 'reply'
 
         try:
@@ -78,12 +73,18 @@ class CommentController(BaseController):
         except:
             abort(404)
 
-        return self._add_or_reply(dataset_id)
+        return self._add_or_reply('reply', dataset_id, content_type, parent_id)
 
-    def _add_or_reply(self, content_item_id, content_type):
+    def _add_or_reply(self, comment_type, content_item_id, content_type, parent_id=None):
         """
-       Allows the user to add a comment to an existing dataset or datarequest
-       """
+        Allows the user to add a comment to an existing dataset or datarequest
+        :param comment_type:
+        :param content_item_id:
+        :param content_type: string 'dataset' or 'datarequest'
+        :return:
+        """
+        content_type = 'dataset' if not vars().has_key('content_type') else content_type
+
         context = {'model': model, 'user': c.user}
 
         data_dict = {'id': content_item_id}
@@ -120,22 +121,31 @@ class CommentController(BaseController):
                 abort(403)
 
             if success:
-                email_notifications. notify_admins_and_commenters(
-                    c.pkg.owner_org,
-                    toolkit.c.userobj,
-                    '/templates/email/notification-new-comment.txt',
-                    'Queensland Government open data portal - New comment',
-                    'dataset' if not vars().has_key('content_type') else content_type,
-                    c.pkg.name,
-                    data_dict['url'],
-                    res['id']
-                )
+                if comment_type == 'reply':
+                    email_notifications.notify_admins_and_other_commenters(
+                        helpers.get_org_id(content_type),
+                        toolkit.c.userobj,
+                        'notification-new-comment',
+                        content_type,
+                        helpers.get_content_item_id(content_type),
+                        res['parent_id'],
+                        res['id']
+                    )
+                else:
+                    email_notifications.notify_admins(
+                        helpers.get_org_id(content_type),
+                        toolkit.c.userobj,
+                        'notification-new-comment',
+                        content_type,
+                        helpers.get_content_item_id(content_type),
+                        res['id']
+                    )
 
             h.redirect_to(
                 helpers.get_redirect_url(
                     content_type,
                     content_item_id if content_type == 'datarequest' else c.pkg.name,
-                    'comment_' + str(res['id']) if success else 'comment_form'
+                    'comment_' + str(res['id']) if success else ('comment_form' if comment_type == 'new' else 'reply_' + str(parent_id))
                 ))
 
         return helpers.render_content_template(content_type)
@@ -177,32 +187,48 @@ class CommentController(BaseController):
 
     def flag(self, comment_id):
         if authz.auth_is_loggedin_user():
-            context = {'model': model, 'user': c.user}
-            comment = get_action('comment_show')(context, {'id': comment_id})
-            if comment and not comment['flagged']:
-                comment['comment'] = comment['content']
-                comment['flagged'] = True
-                get_action('comment_update')(context, comment)
+            # Using the comment model rather than the update action because update action updates modified timestamp
+            comment = comment_model.Comment.get(comment_id)
+            if comment and not comment.flagged:
+                comment.flagged = True
+                model.Session.add(comment)
+                model.Session.commit()
+                email_notifications.flagged_comment_notification(comment)
 
-    def unflag(self, dataset_id, comment_id):
-        if not authz.auth_is_loggedin_user():
-            abort(403)
-
+    def unflag(self, content_type, content_item_id, comment_id):
+        """
+        Remove the 'flagged' attribute on a comment
+        :param content_type: string 'dataset' or 'datarequest'
+        :param content_item_id: string
+        :param comment_id: string ID of the comment to unflag
+        :return:
+        """
         context = {'model': model, 'user': c.user}
-        comment = get_action('comment_show')(context, {'id': comment_id})
 
-        if not comment or not comment['flagged']:
+        # Using the comment model rather than the update action because update action updates modified timestamp
+        comment = comment_model.Comment.get(comment_id)
+
+        if not comment \
+                or not comment.flagged \
+                or not authz.auth_is_loggedin_user() \
+                or not helpers.user_can_manage_comments(content_type, content_item_id):
             abort(403)
 
-        if not check_access('package_update', context, {"id": dataset_id}):
-            abort(403)
+        comment.flagged = False
 
-        c.pkg_dict = get_action('package_show')(context, {'id': dataset_id})
-        c.pkg = context['package']
-        comment['comment'] = comment['content']
-        comment['flagged'] = False
-        get_action('comment_update')(context, comment)
+        model.Session.add(comment)
+        model.Session.commit()
+
         h.flash_success(_('Comment un-flagged'))
-        h.redirect_to(str('/dataset/%s' % c.pkg.name))
 
-        return render("package/read.html")
+        data_dict = {'id': content_item_id}
+
+        if content_type == 'datarequest':
+            c.datarequest = get_action('show_datarequest')(context, data_dict)
+            h.redirect_to(str('/datarequest/comment/%s#comment_%s' % (content_item_id, comment_id)))
+        else:
+            c.pkg_dict = get_action('package_show')(context, data_dict)
+            c.pkg = context['package']
+            h.redirect_to(str('/dataset/%s#comment_%s' % (content_item_id, comment_id)))
+
+        return helpers.render_content_template(content_type)

--- a/ckanext/ytp/comments/controller.py
+++ b/ckanext/ytp/comments/controller.py
@@ -39,12 +39,19 @@ class CommentController(BaseController):
                 success = True
             except ValidationError, ve:
                 log.debug(ve)
+                if ve.error_dict and ve.error_dict.get('message'):
+                    msg = ve.error_dict['message']
+                else:
+                    msg = str(ve)
+                h.flash_error(msg)
             except Exception, e:
                 log.debug(e)
                 abort(403)
 
             if success:
                 h.redirect_to(str('/dataset/%s#comment_%s' % (c.pkg.name, res['id'])))
+            else:
+                h.redirect_to(str('/dataset/%s#edit_%s' % (c.pkg.name, comment_id)))
 
         return render("package/read.html")
 
@@ -89,12 +96,19 @@ class CommentController(BaseController):
                 success = True
             except ValidationError, ve:
                 log.debug(ve)
+                if ve.error_dict and ve.error_dict.get('message'):
+                    msg = ve.error_dict['message']
+                else:
+                    msg = str(ve)
+                h.flash_error(msg)
             except Exception, e:
                 log.debug(e)
                 abort(403)
 
             if success:
                 h.redirect_to(str('/dataset/%s#comment_%s' % (c.pkg.name, res['id'])))
+            else:
+                h.redirect_to(str('/dataset/%s#comment_form' % c.pkg.name))
 
         return render("package/read.html")
 

--- a/ckanext/ytp/comments/email_notifications.py
+++ b/ckanext/ytp/comments/email_notifications.py
@@ -1,0 +1,253 @@
+import ckan.authz as authz
+import ckan.lib.mailer as mailer
+import ckan.logic as logic
+import ckan.model as model
+import ckan.plugins.toolkit as toolkit
+import logging
+import sqlalchemy
+
+from ckan.common import config
+from ckanext.ytp.comments.model import Comment, CommentThread
+
+
+log1 = logging.getLogger(__name__)
+NotFound = logic.NotFound
+_and_ = sqlalchemy.and_
+
+
+def load_notification_template(template):
+    import os
+
+    path = os.path.dirname(os.path.realpath(__file__)) + template
+
+    try:
+        fp = open(path, 'rb')
+        notification_template = fp.read()
+        fp.close()
+
+        return notification_template
+    except IOError as error:
+        log1.error(error)
+        raise
+
+
+def mail_merge(msg, dict):
+
+    if 'organization' in dict:
+        msg = msg.replace('[[ORGANIZATION]]', dict['organization'])
+
+    if 'user' in dict:
+        msg = msg.replace('[[USER]]', dict['user'])
+
+    if 'url' in dict:
+        msg = msg.replace('[[URL]]', dict['url'])
+
+    if 'email' in dict:
+        msg = msg.replace('[[EMAIL]]', dict['email'])
+
+    if 'name' in dict:
+        msg = msg.replace('[[NAME]]', dict['name'])
+
+    if 'comment_id' in dict:
+        msg = msg.replace('[[COMMENT_ID]]', dict['comment_id'])
+
+    return msg
+
+
+def get_member_list(context, data_dict=None):
+    '''
+    :param id: the id or name of the group
+    :type id: string
+    :param object_type: restrict the members returned to those of a given type,
+      e.g. ``'user'`` or ``'package'`` (optional, default: ``None``)
+    :type object_type: string
+    :param capacity: restrict the members returned to those with a given
+      capacity, e.g. ``'member'``, ``'editor'``, ``'admin'``, ``'public'``,
+      ``'private'`` (optional, default: ``None``)
+    :type capacity: string
+
+    :rtype: list of (id, type, capacity) tuples
+
+    :raises: :class:`ckan.logic.NotFound`: if the group doesn't exist
+
+    '''
+    model = context['model']
+
+    group = model.Group.get(logic.get_or_bust(data_dict, 'id'))
+    if not group:
+        raise NotFound
+
+    obj_type = data_dict.get('object_type', None)
+    capacity = data_dict.get('capacity', None)
+
+    q = model.Session.query(model.Member).\
+        filter(model.Member.group_id == group.id).\
+        filter(model.Member.state == "active")
+
+    if obj_type:
+        q = q.filter(model.Member.table_name == obj_type)
+    if capacity:
+        q = q.filter(model.Member.capacity == capacity)
+
+    trans = authz.roles_trans()
+
+    def translated_capacity(capacity):
+        try:
+            return trans[capacity]
+        except KeyError:
+            return capacity
+
+    return [(m.table_id, m.table_name, translated_capacity(m.capacity))
+            for m in q.all()]
+
+
+def get_admin_users_for_org(owner_org, excluded_emails=[]):
+    '''
+    A list of admin user emails for the supplied organisation ID
+    :param owner_org: string
+    :param excluded_emails: list
+    :return:
+    '''
+    admin_users = []
+
+    member_list = get_member_list(
+        {'model': model},
+        {
+            'id': owner_org,
+            'object_type': 'user',
+            'capacity': 'admin'
+        })
+
+    for member in member_list:
+        user = model.User.get(member[0])
+        if user and user.email and user.email not in excluded_emails:
+            admin_users.append(user.email)
+
+    return admin_users
+
+
+def send_notification_email(to, subject, msg):
+    '''
+    Use CKAN mailer logic to send an email to an individual email address
+    :param to: string
+    :param subject: string
+    :param msg: string
+    :return:
+    '''
+    # Attempt to send mail.
+    mail_dict = {
+        'recipient_email': to,
+        'recipient_name': to,
+        'subject': subject,
+        'body': msg,
+        'headers': {'reply-to': config.get('smtp.mail_from')}
+    }
+
+    try:
+        mailer.mail_recipient(**mail_dict)
+    except mailer.MailerException:
+        log1.error(u'Cannot send email notification to %s.', to, exc_info=1)
+
+
+def notify_admin_users(owner_org, template, subject, package_name, comment_id):
+    admin_users = get_admin_users_for_org(owner_org)
+
+    if admin_users:
+        msg = load_notification_template(template)
+
+        msg = mail_merge(msg, {
+            'url': toolkit.url_for('dataset_read', id=package_name, qualified=True),
+            'comment_id': comment_id
+        })
+
+        for user in admin_users:
+            send_notification_email(
+                user,
+                subject,
+                msg
+            )
+
+
+def notify_admins_and_commenters(owner_org, user, template, subject, content_type, content_item_id, thread_url, comment_id):
+    '''
+
+    :param owner_org: organization.id of the content item owner
+    :param user: c.user_obj of the user who submitted the comment
+    :param template: string indicating which email template to use
+    :param subject: string to be used for email subject
+    :param content_item_name:
+    :param thread_url: URL of the comment thread (used to determine other commenters in thread)
+    :param comment_id: ID of the comment submitted (used in URL of email body)
+    :return:
+    '''
+    # Get all the org admin users (excluding the user who made the comment)
+    admin_users = get_admin_users_for_org(owner_org, [user.email])
+
+    # Get all the other commenters (excluding the user who made the comment)
+    other_commenters = get_other_commenters(thread_url, user.email)
+
+    # Combine the two lists
+    users = list(set(admin_users + other_commenters))
+
+    if users:
+        msg = load_notification_template(template)
+        msg = mail_merge(msg, {
+            'url': get_content_item_link(content_type, content_item_id, comment_id)
+        })
+
+        for user in users:
+            send_notification_email(
+                user,
+                subject,
+                msg
+            )
+
+
+def get_other_commenters(thread_url, commenter_email):
+    '''
+    Queries the database to find other commenters for a given thread
+    :param thread_url: URL of the comment thread
+    :param commenter_email: Email address of the user who submitted the comment
+    :return:
+    '''
+    session = model.Session
+
+    comments = (
+        session.query(
+            model.User.email
+        )
+        .join(
+            Comment,
+            Comment.user_id==model.User.id
+        )
+        .join(
+            CommentThread,
+            Comment.thread_id==CommentThread.id
+        )
+        .filter(
+            _and_(
+                CommentThread.url == thread_url,
+                model.User.email != commenter_email,
+            ))
+        .group_by(model.User.email)
+    )
+
+    return [email[0] for email in comments.all()]
+
+
+def get_content_item_link(content_type, content_item_id, comment_id=None):
+    '''
+    Get a fully qualified URL to the content item being commented on.
+    :param content_type: string Currently only supports 'dataset' or 'datarequest'
+    :param content_item_id: string Package name, or Data Request ID
+    :param comment_id: string `comment`.`id`
+    :return:
+    '''
+    url = ''
+    if content_type == 'datarequest':
+        url = toolkit.url_for('datarequest_comment', id=content_item_id, qualified=True)
+    else:
+        url = toolkit.url_for('dataset_read', id=content_item_id, qualified=True)
+    if comment_id:
+        url += '#comment_' + str(comment_id)
+    return url

--- a/ckanext/ytp/comments/helpers.py
+++ b/ckanext/ytp/comments/helpers.py
@@ -3,6 +3,10 @@ import re
 
 from ckan.common import config, request
 from profanity import profanity
+from ckan.common import c
+from ckan.lib.base import render
+from ckan.logic import check_access, get_action
+from ckanext.datarequests import actions
 
 
 def threaded_comments_enabled():
@@ -28,3 +32,32 @@ def load_bad_words():
     x = f.read().splitlines()
     f.close()
     return x
+
+
+def get_content_item(content_type, context, data_dict):
+    if content_type == 'datarequest':
+        c.datarequest = actions.show_datarequest(context, data_dict)
+    else:
+        data_dict['include_tracking'] = True
+        c.pkg_dict = get_action('package_show')(context, data_dict)
+        c.pkg = context['package']
+
+
+def check_content_access(content_type, context, data_dict):
+    if content_type == 'dataset':
+        check_access('package_show', context, data_dict)
+    elif content_type == 'datareqest':
+        check_access('show_datarequest', context, data_dict)
+
+
+def get_redirect_url(content_type, content_item_id, anchor):
+    if content_type == 'datarequest':
+        return str('/datarequest/comment/%s#%s' % (content_item_id, anchor))
+    else:
+        return str('/dataset/%s#%s' % (content_item_id, anchor))
+
+
+def render_content_template(content_type):
+    return render(
+        'datarequests/comment.html' if content_type == 'datarequest' else "package/read.html"
+    )

--- a/ckanext/ytp/comments/helpers.py
+++ b/ckanext/ytp/comments/helpers.py
@@ -1,5 +1,4 @@
 import ckan.plugins.toolkit as toolkit
-import re
 
 from ckan.common import config, request
 from profanity import profanity
@@ -25,9 +24,8 @@ def profanity_check(cleaned_comment):
 def load_bad_words():
     filepath = config.get('ckan.comments.bad_words_file', None)
     if not filepath:
-        # @todo: dynamically set this path
-        filepath = '/usr/lib/ckan/default/src/ckanext-ytp-comments/ckanext/ytp/comments/bad_words.txt'
-
+        import os
+        filepath = os.path.dirname(os.path.realpath(__file__)) + '/bad_words.txt'
     f = open(filepath, 'r')
     x = f.read().splitlines()
     f.close()
@@ -44,20 +42,41 @@ def get_content_item(content_type, context, data_dict):
 
 
 def check_content_access(content_type, context, data_dict):
-    if content_type == 'dataset':
-        check_access('package_show', context, data_dict)
-    elif content_type == 'datareqest':
-        check_access('show_datarequest', context, data_dict)
+    check_access('show_datarequest' if content_type == 'datareqest' else 'package_show', context, data_dict)
 
 
 def get_redirect_url(content_type, content_item_id, anchor):
-    if content_type == 'datarequest':
-        return str('/datarequest/comment/%s#%s' % (content_item_id, anchor))
-    else:
-        return str('/dataset/%s#%s' % (content_item_id, anchor))
+    return '/%s/%s#%s' % (
+        'datarequest/comment' if content_type == 'datarequest' else 'dataset',
+        content_item_id,
+        anchor
+    )
 
 
 def render_content_template(content_type):
     return render(
         'datarequests/comment.html' if content_type == 'datarequest' else "package/read.html"
     )
+
+
+def user_can_edit_comment(comment_user_id):
+    user = toolkit.c.userobj
+    if user and comment_user_id == user.id and users_can_edit():
+        return True
+    return False
+
+
+def user_can_manage_comments(content_type, content_item_id):
+    if content_type == 'datarequest':
+        return toolkit.h.check_access('update_datarequest', {'id': content_item_id})
+    elif content_type == 'dataset':
+        return toolkit.h.check_access('package_update', {'id': content_item_id})
+    return False
+
+
+def get_org_id(content_type):
+    return c.datarequest['organization_id'] if content_type == 'datarequest' else c.pkg.owner_org
+
+
+def get_content_item_id(content_type):
+    return c.datarequest['id'] if content_type == 'datarequest' else c.pkg.name

--- a/ckanext/ytp/comments/helpers.py
+++ b/ckanext/ytp/comments/helpers.py
@@ -1,0 +1,30 @@
+import ckan.plugins.toolkit as toolkit
+import re
+
+from ckan.common import config, request
+from profanity import profanity
+
+
+def threaded_comments_enabled():
+    return toolkit.asbool(config.get('ckan.comments.threaded_comments', False))
+
+
+def users_can_edit():
+    return toolkit.asbool(config.get('ckan.comments.users_can_edit', False))
+
+
+def profanity_check(cleaned_comment):
+    profanity.load_words(load_bad_words())
+    return profanity.contains_profanity(cleaned_comment)
+
+
+def load_bad_words():
+    filepath = config.get('ckan.comments.bad_words_file', None)
+    if not filepath:
+        # @todo: dynamically set this path
+        filepath = '/usr/lib/ckan/default/src/ckanext-ytp-comments/ckanext/ytp/comments/bad_words.txt'
+
+    f = open(filepath, 'r')
+    x = f.read().splitlines()
+    f.close()
+    return x

--- a/ckanext/ytp/comments/logic/action/create.py
+++ b/ckanext/ytp/comments/logic/action/create.py
@@ -1,7 +1,10 @@
 import datetime
+import ckan.plugins.toolkit as toolkit
 import ckanext.ytp.comments.model as comment_model
 import ckanext.ytp.comments.util as util
 from ckan import logic
+from ckan.common import config
+from ckanext.ytp.comments import helpers
 from pprint import pprint
 import logging
 
@@ -35,6 +38,12 @@ def comment_create(context, data_dict):
 
     # Cleanup the comment
     cleaned_comment = util.clean_input(data_dict.get('comment'))
+
+    # Run profanity check
+    if toolkit.asbool(config.get('ckan.comments.check_for_profanity', False)) \
+            and (helpers.profanity_check(cleaned_comment)
+                 or helpers.profanity_check(data_dict.get('subject'))):
+        raise logic.ValidationError({"message": "Comment blocked due to profanity."})
 
     # Create the object
     cmt = comment_model.Comment(thread_id=thread_id,

--- a/ckanext/ytp/comments/logic/action/create.py
+++ b/ckanext/ytp/comments/logic/action/create.py
@@ -12,8 +12,6 @@ log = logging.getLogger(__name__)
 
 
 def comment_create(context, data_dict):
-    pprint(data_dict)
-    pprint(context)
     model = context['model']
     user = context['user']
 

--- a/ckanext/ytp/comments/logic/action/update.py
+++ b/ckanext/ytp/comments/logic/action/update.py
@@ -1,9 +1,13 @@
 import datetime
+import ckan.plugins.toolkit as toolkit
 import ckanext.ytp.comments.model as comment_model
 import ckanext.ytp.comments.util as util
 from ckan import logic
 from ckan.lib.base import abort
 import logging
+
+from ckan.common import config
+from ckanext.ytp.comments import helpers
 
 log = logging.getLogger(__name__)
 
@@ -24,6 +28,12 @@ def comment_update(context, data_dict):
 
     # Cleanup the comment
     cleaned_comment = util.clean_input(data_dict.get('comment'))
+
+    # Run profanity check
+    if toolkit.asbool(config.get('ckan.comments.check_for_profanity', False)) \
+            and (helpers.profanity_check(cleaned_comment)
+                 or helpers.profanity_check(data_dict.get('subject'))):
+        raise logic.ValidationError("Comment blocked due to profanity.")
 
     comment.subject = data_dict.get('subject')
     comment.comment = cleaned_comment

--- a/ckanext/ytp/comments/logic/action/update.py
+++ b/ckanext/ytp/comments/logic/action/update.py
@@ -39,6 +39,8 @@ def comment_update(context, data_dict):
     comment.comment = cleaned_comment
     comment.modified_date = datetime.datetime.now()
 
+    comment.flagged = data_dict.get('flagged')
+
     model.Session.add(comment)
     model.Session.commit()
 

--- a/ckanext/ytp/comments/model.py
+++ b/ckanext/ytp/comments/model.py
@@ -250,6 +250,8 @@ class Comment(Base):
         else:
             d['comments'] = [c.as_dict() for c in self.children]
         d['flagged'] = self.flagged
+        if self.parent_id:
+            d['parent_id'] = self.parent_id
         return d
 
     @classmethod

--- a/ckanext/ytp/comments/model.py
+++ b/ckanext/ytp/comments/model.py
@@ -197,6 +197,8 @@ class Comment(Base):
 
     state = Column(types.UnicodeText, default=u'active')
 
+    flagged = Column(types.Boolean, default=False)
+
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
             setattr(self, k, v)
@@ -247,6 +249,7 @@ class Comment(Base):
             d['comments'] = [c.as_dict() for c in self.children if c.state == 'active']
         else:
             d['comments'] = [c.as_dict() for c in self.children]
+        d['flagged'] = self.flagged
         return d
 
     @classmethod

--- a/ckanext/ytp/comments/plugin.py
+++ b/ckanext/ytp/comments/plugin.py
@@ -70,6 +70,10 @@ class YtpCommentsPlugin(plugins.SingletonPlugin):
         map.connect('/dataset/{dataset_id}/comments/{comment_id}/edit', controller=controller, action='edit')
         map.connect('/dataset/{dataset_id}/comments/{parent_id}/reply', controller=controller, action='reply')
         map.connect('/dataset/{dataset_id}/comments/{comment_id}/delete', controller=controller, action='delete')
+        # Flag a comment as inappropriate
+        map.connect('/comment/{comment_id}/flag', controller=controller, action='flag')
+        # Un-flag a comment as inappropriate
+        map.connect('/dataset/{dataset_id}/comments/{comment_id}/unflag', controller=controller, action='unflag')
         return map
 
     def _get_comment_thread(self, dataset_name):

--- a/ckanext/ytp/comments/plugin.py
+++ b/ckanext/ytp/comments/plugin.py
@@ -67,24 +67,26 @@ class YtpCommentsPlugin(plugins.SingletonPlugin):
         """
         controller = 'ckanext.ytp.comments.controller:CommentController'
         map.connect('/dataset/{dataset_id}/comments/add', controller=controller, action='add')
-        map.connect('/dataset/{dataset_id}/comments/{comment_id}/edit', controller=controller, action='edit')
+        map.connect('/{content_type}/{dataset_id}/comments/add', controller=controller, action='add')
+        #map.connect('/dataset/{dataset_id}/comments/{comment_id}/edit', controller=controller, action='edit')
+        map.connect('/{content_type}/{content_item_id}/comments/{comment_id}/edit', controller=controller, action='edit')
         map.connect('/dataset/{dataset_id}/comments/{parent_id}/reply', controller=controller, action='reply')
-        map.connect('/dataset/{dataset_id}/comments/{comment_id}/delete', controller=controller, action='delete')
+        map.connect('/{content_type}/{content_item_id}/comments/{comment_id}/delete', controller=controller, action='delete')
         # Flag a comment as inappropriate
         map.connect('/comment/{comment_id}/flag', controller=controller, action='flag')
         # Un-flag a comment as inappropriate
         map.connect('/dataset/{dataset_id}/comments/{comment_id}/unflag', controller=controller, action='unflag')
         return map
 
-    def _get_comment_thread(self, dataset_name):
+    def _get_comment_thread(self, dataset_name, content_type='dataset'):
         import ckan.model as model
         from ckan.logic import get_action
-        url = '/dataset/%s' % dataset_name
+        url = '/%s/%s' % (content_type, dataset_name)
         return get_action('thread_show')({'model': model, 'with_deleted': True}, {'url': url})
 
-    def _get_comment_count_for_dataset(self, dataset_name):
+    def _get_comment_count_for_dataset(self, dataset_name, content_type='dataset'):
         import ckan.model as model
         from ckan.logic import get_action
-        url = '/dataset/%s' % dataset_name
+        url = '/%s/%s' % (content_type, dataset_name)
         count = get_action('comment_count')({'model': model}, {'url': url})
         return count

--- a/ckanext/ytp/comments/plugin.py
+++ b/ckanext/ytp/comments/plugin.py
@@ -1,6 +1,9 @@
 import ckan.plugins as plugins
+import ckan.model as model
+from ckan.logic import get_action
 from ckan.plugins import implements, toolkit
 
+import helpers
 import logging
 
 log = logging.getLogger(__name__)
@@ -27,7 +30,12 @@ class YtpCommentsPlugin(plugins.SingletonPlugin):
     def get_helpers(self):
         return {
             'get_comment_thread': self._get_comment_thread,
-            'get_comment_count_for_dataset': self._get_comment_count_for_dataset
+            'get_comment_count_for_dataset': self._get_comment_count_for_dataset,
+            'threaded_comments_enabled': helpers.threaded_comments_enabled,
+            'users_can_edit': helpers.users_can_edit,
+            'user_can_edit_comment': helpers.user_can_edit_comment,
+            'user_can_manage_comments': helpers.user_can_manage_comments,
+            'get_org_id': helpers.get_org_id,
         }
 
     def get_actions(self):
@@ -70,23 +78,19 @@ class YtpCommentsPlugin(plugins.SingletonPlugin):
         map.connect('/{content_type}/{dataset_id}/comments/add', controller=controller, action='add')
         #map.connect('/dataset/{dataset_id}/comments/{comment_id}/edit', controller=controller, action='edit')
         map.connect('/{content_type}/{content_item_id}/comments/{comment_id}/edit', controller=controller, action='edit')
-        map.connect('/dataset/{dataset_id}/comments/{parent_id}/reply', controller=controller, action='reply')
+        map.connect('/{content_type}/{dataset_id}/comments/{parent_id}/reply', controller=controller, action='reply')
         map.connect('/{content_type}/{content_item_id}/comments/{comment_id}/delete', controller=controller, action='delete')
         # Flag a comment as inappropriate
         map.connect('/comment/{comment_id}/flag', controller=controller, action='flag')
         # Un-flag a comment as inappropriate
-        map.connect('/dataset/{dataset_id}/comments/{comment_id}/unflag', controller=controller, action='unflag')
+        map.connect('/{content_type}/{content_item_id}/comments/{comment_id}/unflag', controller=controller, action='unflag')
         return map
 
     def _get_comment_thread(self, dataset_name, content_type='dataset'):
-        import ckan.model as model
-        from ckan.logic import get_action
         url = '/%s/%s' % (content_type, dataset_name)
         return get_action('thread_show')({'model': model, 'with_deleted': True}, {'url': url})
 
     def _get_comment_count_for_dataset(self, dataset_name, content_type='dataset'):
-        import ckan.model as model
-        from ckan.logic import get_action
         url = '/%s/%s' % (content_type, dataset_name)
         count = get_action('comment_count')({'model': model}, {'url': url})
         return count

--- a/ckanext/ytp/comments/public/javascript/comment_validation.js
+++ b/ckanext/ytp/comments/public/javascript/comment_validation.js
@@ -1,0 +1,73 @@
+function hideFormErrors()
+{
+    jQuery('#comment_form_errors').addClass('hidden');
+    jQuery('#comment_form_errors li').addClass('hidden');
+}
+
+function showFormErrors()
+{
+    jQuery('#comment_form_errors').removeClass('hidden');
+}
+
+function showFormError(id, error_name)
+{
+    jQuery('#' + id + ' .error-' + error_name).removeClass('hidden');
+}
+
+function showEditFormErrors(id)
+{
+    jQuery('#' + id + ' .edit_form_errors').removeClass('hidden');
+}
+
+jQuery(document).ready(function() {
+
+    jQuery('.module-content input[type="submit"]').on('click', function(e) {
+        if (jQuery(this).hasClass('btn-primary')) {
+            var form = jQuery(this).closest('form');
+            var comment = form.find('textarea[name="comment"]').val();
+            var display_errors = false;
+
+            hideFormErrors();
+
+            if (!comment) {
+                jQuery('#comment_form_errors .error-comment').removeClass('hidden');
+                display_errors = true;
+            }
+            if (display_errors) {
+                showFormErrors();
+                return false;
+            }
+        }
+    });
+
+    if (window.location.hash) {
+        var hash = window.location.hash;
+        var hash_no_hash = hash.substring(1); //Puts hash in variable, and removes the # character
+        if (hash_no_hash == 'comment_form') {
+            //  Regex the flash-messages for 'subject' 'comment' and 'profanity'
+            if (jQuery('#content .flash-messages').children().length > 0) {
+                var error_message = jQuery('#content .flash-messages').text()
+                //  Check for profanity error message
+                if (error_message.search("profanity") !== -1) {
+                    jQuery('#comment_form_errors .error-profanity').removeClass('hidden');
+                    showFormErrors();
+                }
+            }
+        }
+        else if (hash_no_hash.indexOf('edit_') !== -1) {
+            var form_wrapper_id = 'comment_form_' + hash_no_hash;
+            jQuery(hash).removeClass('hidden');
+            document.getElementById(form_wrapper_id).scrollIntoView();
+            //  Regex the flash-messages for 'subject' 'comment' and 'profanity'
+            if (jQuery('#content .flash-messages').children().length > 0) {
+                var error_message = jQuery('#content .flash-messages').text()
+                //  Check for profanity error message
+                if (error_message.search("profanity") !== -1) {
+                    showFormError(form_wrapper_id, 'profanity');
+                    showEditFormErrors(form_wrapper_id);
+                }
+            }
+        }
+    }
+
+});

--- a/ckanext/ytp/comments/public/javascript/comment_validation.js
+++ b/ckanext/ytp/comments/public/javascript/comment_validation.js
@@ -1,7 +1,7 @@
 function hideFormErrors()
 {
-    jQuery('#comment_form_errors').addClass('hidden');
-    jQuery('#comment_form_errors li').addClass('hidden');
+    jQuery('.form_errors').addClass('hidden');
+    jQuery('.form_errors li').addClass('hidden');
 }
 
 function showFormErrors()
@@ -19,6 +19,11 @@ function showEditFormErrors(id)
     jQuery('#' + id + ' .edit_form_errors').removeClass('hidden');
 }
 
+function showReplyFormErrors(id)
+{
+    jQuery('#' + id + ' .reply_form_errors').removeClass('hidden');
+}
+
 jQuery(document).ready(function() {
 
     jQuery('.module-content input[type="submit"]').on('click', function(e) {
@@ -30,11 +35,11 @@ jQuery(document).ready(function() {
             hideFormErrors();
 
             if (!comment) {
-                jQuery('#comment_form_errors .error-comment').removeClass('hidden');
+                form.find('.error-comment').removeClass('hidden');
                 display_errors = true;
             }
             if (display_errors) {
-                showFormErrors();
+                form.find('.form-errors').removeClass('hidden');
                 return false;
             }
         }
@@ -67,6 +72,24 @@ jQuery(document).ready(function() {
                     showEditFormErrors(form_wrapper_id);
                 }
             }
+        }
+        else if (hash_no_hash.indexOf('reply_') !== -1) {
+            var form_wrapper_id = 'comment_form_' + hash_no_hash;
+            var parent_comment_wrapper_id = 'comment_' + hash_no_hash.replace('reply_', '');
+            jQuery(hash).removeClass('hidden');
+            document.getElementById(parent_comment_wrapper_id).scrollIntoView();
+            //  Regex the flash-messages for 'subject' 'comment' and 'profanity'
+            if (jQuery('#content .flash-messages').children().length > 0) {
+                var error_message = jQuery('#content .flash-messages').text()
+                //  Check for profanity error message
+                if (error_message.search("profanity") !== -1) {
+                    showFormError(form_wrapper_id, 'profanity');
+                    showReplyFormErrors(form_wrapper_id);
+                }
+            }
+        }
+        else if (hash.indexOf('#comment_') !== -1) {
+            jQuery(hash).addClass('highlight');
         }
     }
 

--- a/ckanext/ytp/comments/templates/email/notification-new-comment.txt
+++ b/ckanext/ytp/comments/templates/email/notification-new-comment.txt
@@ -1,0 +1,3 @@
+A comment has been made on the Queensland Government open data portal that may be relevant to you.
+
+[[URL]]

--- a/ckanext/ytp/comments/templates/emails/bodies/notification-flagged-comment.txt
+++ b/ckanext/ytp/comments/templates/emails/bodies/notification-flagged-comment.txt
@@ -1,0 +1,5 @@
+This comment has been flagged as inappropriate by a user. Please review and choose from the options: remove flag, edit comment or delete comment.
+
+{{ url }}
+
+Do not reply to this email.

--- a/ckanext/ytp/comments/templates/emails/bodies/notification-new-comment.txt
+++ b/ckanext/ytp/comments/templates/emails/bodies/notification-new-comment.txt
@@ -1,3 +1,5 @@
 A comment has been made on the Queensland Government open data portal that may be relevant to you.
 
-[[URL]]
+{{ url }}
+
+Do not reply to this email.

--- a/ckanext/ytp/comments/templates/emails/subjects/notification-flagged-comment.txt
+++ b/ckanext/ytp/comments/templates/emails/subjects/notification-flagged-comment.txt
@@ -1,0 +1,1 @@
+Queensland Government Open Data - Comments

--- a/ckanext/ytp/comments/templates/emails/subjects/notification-new-comment.txt
+++ b/ckanext/ytp/comments/templates/emails/subjects/notification-new-comment.txt
@@ -1,0 +1,1 @@
+Queensland Government Open Data - Comments

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+profanity

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 profanity
+lxml


### PR DESCRIPTION
This feature branch incorporates the following enhancements to the YTP Comments base extension:
- minor adjustments to make the extension work in CKAN 2.7+
- validation of submitted comments to ensure comment text is submitted
- blocking of comments based on a profanity filter of bad words
- ability for logged in CKAN users to flag a comment as inappropriate
- email notifications for new comments, replies to comments and flagging of inappropriate comments
- supports comments on datasets and data requests
- additional functionality to support threading of comments to 1st level (i.e. replies to top level comments)