### PR TITLE
[DQL2-27] store timestamps as UTC since the zone data will be lost

### DIFF
--- a/ckanext/ytp/comments/logic/action/update.py
+++ b/ckanext/ytp/comments/logic/action/update.py
@@ -36,7 +36,7 @@ def comment_update(context, data_dict):
 
     comment.subject = data_dict.get('subject')
     comment.comment = cleaned_comment
-    comment.modified_date = datetime.datetime.now()
+    comment.modified_date = datetime.datetime.utcnow()
 
     comment.flagged = data_dict.get('flagged')
 

--- a/ckanext/ytp/comments/model.py
+++ b/ckanext/ytp/comments/model.py
@@ -35,7 +35,7 @@ class CommentThread(Base):
 
     id = Column(types.UnicodeText, primary_key=True, default=make_uuid)
     url = Column(types.UnicodeText)
-    creation_date = Column(types.DateTime, default=datetime.datetime.now)
+    creation_date = Column(types.DateTime, default=datetime.datetime.utcnow)
     locked = Column(types.Boolean, default=False)
 
     def __init__(self, **kwargs):
@@ -191,7 +191,7 @@ class Comment(Base):
     subject = Column(types.UnicodeText)
     comment = Column(types.UnicodeText)
 
-    creation_date = Column(types.DateTime, default=datetime.datetime.now)
+    creation_date = Column(types.DateTime, default=datetime.datetime.utcnow)
     modified_date = Column(types.DateTime)
     approval_status = Column(types.UnicodeText)
 
@@ -283,7 +283,7 @@ class CommentBlockedUser(Base):
     id = Column(types.UnicodeText, primary_key=True, default=make_uuid)
     user_id = Column(types.UnicodeText, ForeignKey(model.User.id))
     blocked_by = Column(types.UnicodeText, ForeignKey(model.User.id))
-    creation_date = Column(types.DateTime, default=datetime.datetime.now)
+    creation_date = Column(types.DateTime, default=datetime.datetime.utcnow)
 
     def __init__(self, **kwargs):
         for k, v in kwargs.items():

--- a/ckanext/ytp/comments/notification_models.py
+++ b/ckanext/ytp/comments/notification_models.py
@@ -23,7 +23,7 @@ class CommentNotificationRecipient(object):
 comment_notification_recipient_table = Table('comment_notification_recipient', metadata,
                                              Column('id', types.UnicodeText, primary_key=True,
                                                     default=make_uuid),
-                                             Column('timestamp', types.DateTime, default=datetime.datetime.utcnow()),
+                                             Column('timestamp', types.DateTime, default=datetime.datetime.utcnow),
                                              Column('user_id', types.UnicodeText),
                                              Column('thread_id', types.UnicodeText),
                                              Column('comment_id', types.UnicodeText, default=u''),


### PR DESCRIPTION
They can be converted to the desired time zone for formatting when being displayed.