### PR TITLE
[QOL-8368] strip out Data Request testing

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -121,7 +121,7 @@ commands:
       ahoy start-ckan-job-worker &
       ahoy start-mailmock &
       sleep 5 &&
-      ahoy cli "behave ${*:-test/features} --tags ~datarequest --tags ~comment-report" || \
+      ahoy cli "behave ${*:-test/features} --tags ~comment-report" || \
       [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]
       ahoy stop-mailmock
       ahoy stop-ckan-job-worker

--- a/.docker/Dockerfile.ckan
+++ b/.docker/Dockerfile.ckan
@@ -2,7 +2,7 @@ FROM amazeeio/python:2.7-ckan-21.8.0
 
 ARG SITE_URL=http://ckan:3000/
 ARG CKAN_REPO=ckan/ckan
-ARG CKAN_VERSION=2.8.8-qgov.5
+ARG CKAN_VERSION=2.8.8
 ENV SITE_URL="${SITE_URL}"
 ENV VENV_DIR=/app/ckan/default
 ENV APP_DIR=/app

--- a/.docker/scripts/create-test-data.sh
+++ b/.docker/scripts/create-test-data.sh
@@ -96,50 +96,6 @@ package_owner_org_update=$( \
 )
 echo ${package_owner_org_update}
 
-##
-# BEGIN: Create a Data Request organisation with test users for admin, editor and member and default data requests
-#
-# Data Requests requires a specific organisation to exist in order to create DRs for Data.Qld
-DR_ORG_NAME=open-data-administration-data-requests
-DR_ORG_TITLE="Open Data Administration (data requests)"
-
-echo "Creating test users for ${DR_ORG_TITLE} Organisation:"
-
-add_user_if_needed dr_admin "Data Request Admin" dr_admin@localhost
-add_user_if_needed dr_editor "Data Request Editor" dr_editor@localhost
-add_user_if_needed dr_member "Data Request Member" dr_member@localhost
-
-echo "Creating ${DR_ORG_TITLE} Organisation:"
-
-DR_ORG=$( \
-    curl -LsH "Authorization: ${API_KEY}" \
-    --data "name=${DR_ORG_NAME}&title=${DR_ORG_TITLE}" \
-    ${CKAN_ACTION_URL}/organization_create
-)
-
-DR_ORG_ID=$(echo $DR_ORG | sed -r 's/^(.*)"id": "(.*)",(.*)/\2/')
-
-echo "Assigning test users to ${DR_ORG_TITLE} Organisation:"
-
-curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=${DR_ORG_ID}&object=dr_admin&object_type=user&capacity=admin" \
-    ${CKAN_ACTION_URL}/member_create
-
-curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=${DR_ORG_ID}&object=dr_editor&object_type=user&capacity=editor" \
-    ${CKAN_ACTION_URL}/member_create
-
-curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=${DR_ORG_ID}&object=dr_member&object_type=user&capacity=member" \
-    ${CKAN_ACTION_URL}/member_create
-
-
-echo "Creating test Data Request:"
-
-curl -LsH "Authorization: ${API_KEY}" \
-    --data "title=Test Request&description=This is an example&organization_id=${TEST_ORG_ID}" \
-    ${CKAN_ACTION_URL}/create_datarequest
-
 if [ "$VENV_DIR" != "" ]; then
   deactivate
 fi

--- a/.docker/test.ini
+++ b/.docker/test.ini
@@ -98,7 +98,7 @@ ckan.redis.url = redis://redis:6379
 #       Add ``resource_proxy`` to enable resource proxying and get around the
 #       same origin policy
 # @todo:setup Cleanup the list to use only required plugins.
-ckan.plugins = stats text_view image_view recline_view datarequests datastore ytp_comments
+ckan.plugins = stats text_view image_view recline_view datastore ytp_comments
 
 
 # Define which views should be created by default
@@ -166,16 +166,6 @@ ckan.harvest.mq.type = redis
 ckan.harvest.mq.hostname = redis
 ckan.harvest.mq.port = 6379
 ckan.harvest.mq.redis_db = 0
-
-## ckanext-datarequests settings
-# Enable or disable the comments system by setting up the ckan.datarequests.comments property in the configuration file (by default, the comments system is enabled).
-ckan.datarequests.comments = true
-# Enable or disable a badge to show the number of data requests in the menu by setting up the ckan.datarequests.show_datarequests_badge property in the configuration file (by default, the badge is not shown).
-ckan.datarequests.show_datarequests_badge = true
-# Enable or disable description as a required field on data request forms
-ckan.datarequests.description_required = true
-# Default organisation used for new data requests
-ckan.datarequests.default_organisation = open-data-administration-data-requests
 
 # YTP Comments
 ckan.comments.moderation = False

--- a/.docker/test.ini
+++ b/.docker/test.ini
@@ -169,7 +169,7 @@ ckan.harvest.mq.redis_db = 0
 
 ## ckanext-datarequests settings
 # Enable or disable the comments system by setting up the ckan.datarequests.comments property in the configuration file (by default, the comments system is enabled).
-ckan.datarequests.comments = false
+ckan.datarequests.comments = true
 # Enable or disable a badge to show the number of data requests in the menu by setting up the ckan.datarequests.show_datarequests_badge property in the configuration file (by default, the badge is not shown).
 ckan.datarequests.show_datarequests_badge = true
 # Enable or disable description as a required field on data request forms

--- a/.flake8
+++ b/.flake8
@@ -15,7 +15,7 @@ max-complexity = 10
 
 # List ignore rules one per line.
 ignore =
-    E501
     C901
+    E501
     E722
     W503

--- a/ckanext/ytp/comments/controllers/__init__.py
+++ b/ckanext/ytp/comments/controllers/__init__.py
@@ -66,12 +66,12 @@ def _follow_or_mute(thread_or_comment_id, action):
     :return:
     """
     if not _valid_request_and_user(thread_or_comment_id):
-        abort(404)
+        return abort(404)
 
     thread, comment = notification_helpers.get_thread_comment_or_both(thread_or_comment_id)
 
     if not thread or (comment and not thread):
-        abort(404)
+        return abort(404)
 
     notification_level = 'content_item' if not comment else 'top_level_comment'
 
@@ -103,7 +103,7 @@ def edit(content_type, content_item_id, comment_id):
         # Load the content item
         helpers.get_content_item(content_type, context, data_dict)
     except:
-        abort(403)
+        return abort(403)
 
     if request.method == 'POST':
         data_dict = clean_dict(unflatten(
@@ -124,7 +124,7 @@ def edit(content_type, content_item_id, comment_id):
             h.flash_error(msg)
         except Exception as e:
             log.debug(e)
-            abort(403)
+            return abort(403)
 
         return h.redirect_to(
             helpers.get_redirect_url(
@@ -145,7 +145,7 @@ def reply(content_type, dataset_id, parent_id):
                                                    data)
         c.parent = data['comment']
     except:
-        abort(404)
+        return abort(404)
 
     return _add_or_reply('reply', dataset_id, content_type, parent_id)
 
@@ -171,7 +171,7 @@ def _add_or_reply(comment_type, content_item_id, content_type, parent_id=None):
         # Load the content item
         helpers.get_content_item(content_type, context, data_dict)
     except:
-        abort(403)
+        return abort(403)
 
     if request.method == 'POST':
         data_dict = clean_dict(unflatten(
@@ -193,7 +193,7 @@ def _add_or_reply(comment_type, content_item_id, content_type, parent_id=None):
             h.flash_error(msg)
         except Exception as e:
             log.debug(e)
-            abort(403)
+            return abort(403)
 
         if success:
             email_notifications.notify_admins_and_comment_notification_recipients(
@@ -238,7 +238,7 @@ def delete(content_type, content_item_id, comment_id):
         # Load the content item
         helpers.get_content_item(content_type, context, data_dict)
     except:
-        abort(403)
+        return abort(403)
 
     try:
         data_dict = {'id': comment_id, 'content_type': content_type, 'content_item_id': content_item_id}
@@ -268,6 +268,7 @@ def flag(comment_id):
             model.Session.add(comment)
             model.Session.commit()
             email_notifications.flagged_comment_notification(comment)
+    return ""
 
 
 def unflag(content_type, content_item_id, comment_id):
@@ -287,7 +288,7 @@ def unflag(content_type, content_item_id, comment_id):
             or not comment.flagged \
             or not authz.auth_is_loggedin_user() \
             or not helpers.user_can_manage_comments(content_type, content_item_id):
-        abort(403)
+        return abort(403)
 
     comment.flagged = False
 
@@ -321,6 +322,6 @@ def dataset_comments(dataset_id):
         # Load the content item
         helpers.get_content_item(content_type, context, data_dict)
     except:
-        abort(403)
+        return abort(403)
     return toolkit.render('package/comments.html', extra_vars={
         'pkg': c.pkg, 'pkg_dict': c.pkg_dict})

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,3 @@ flake8==3.8.3
 mock
 pytest-ckan
 splinter>=0.13.0,<0.17
-
--e git+https://github.com/ckan/ckanext-scheming@release-1.2.0#egg=ckanext-scheming
--e git+https://github.com/qld-gov-au/ckanext-datarequests@2.2.0-qgov#egg=ckanext-datarequests

--- a/test/features/comments.feature
+++ b/test/features/comments.feature
@@ -55,7 +55,7 @@ Feature: Comments
         Then I should see "sex" within 10 seconds
 
     @comment-add @comment-profane @datarequest
-    Scenario: When a logged-in user submits a comment containing profanity on a Data Request they should receive an error message and the commment will not appear
+    Scenario: When a logged-in user submits a comment containing profanity on a Data Request they should receive an error message and the comment will not appear
         Given "CKANUser" as the persona
         When I log in
         And I go to data request "Test Request" comments

--- a/test/features/comments.feature
+++ b/test/features/comments.feature
@@ -24,26 +24,6 @@ Feature: Comments
         Then I should see "This is a test comment" within 10 seconds
         And I should see an element with xpath "//div[contains(@class, 'comment-wrapper') and contains(string(), 'This is a test comment')]"
 
-    @comment-add @datarequest
-    Scenario: When a logged-in user submits a comment on a Data Request the comment should then be visible on the Comments tab of the Data Request
-        Given "CKANUser" as the persona
-        When I log in
-        And I go to data request "Test Request" comments
-        Then I should see the add comment form
-        Then I submit a comment with subject "Test subject" and comment "This is a test comment"
-        Then I should see "This is a test comment" within 10 seconds
-
-    @comment-add @datarequest @comment-email
-    Scenario: When a logged-in user submits a comment on a Data Request the email should contain title and comment
-        Given "CKANUser" as the persona
-        When I log in
-        And I go to data request "Test Request" comments
-        Then I should see the add comment form
-        Then I submit a comment with subject "Test Request" and comment "This is a test data request comment"
-        When I wait for 5 seconds
-        Then I should receive a base64 email at "test_org_admin@localhost" containing "Data request subject: Test Request"
-        And I should receive a base64 email at "test_org_admin@localhost" containing "Comment: This is a test data request comment"
-
     @comment-add @comment-profane
     Scenario: When a logged-in user submits a comment containing whitelisted profanity on a Dataset the comment should display within 10 seconds
         Given "CKANUser" as the persona
@@ -54,30 +34,11 @@ Feature: Comments
         Then I submit a comment with subject "Test subject" and comment "sex"
         Then I should see "sex" within 10 seconds
 
-    @comment-add @comment-profane @datarequest
-    Scenario: When a logged-in user submits a comment containing profanity on a Data Request they should receive an error message and the comment will not appear
-        Given "CKANUser" as the persona
-        When I log in
-        And I go to data request "Test Request" comments
-        Then I should see the add comment form
-        Then I submit a comment with subject "Test subject" and comment "Soccer balls"
-        Then I should see "Comment blocked due to profanity" within 5 seconds
-
     @comment-report
     Scenario: When a logged-in user reports a comment on a Dataset the comment should be marked as reported and an email sent to the admins of the organisation
         Given "CKANUser" as the persona
         When I log in
         Then I go to dataset "warandpeace" comments
-        And I press the element with xpath "//a[contains(string(), 'Report')]"
-        Then I should see "Reported" within 5 seconds
-        When I wait for 3 seconds
-        Then I should receive a base64 email at "test_org_admin@localhost" containing "This comment has been flagged as inappropriate by a user"
-
-    @comment-report @datarequest
-    Scenario: When a logged-in user reports a comment on a Data Request the comment should be marked as reported and an email notification sent to the organisation admins
-        Given "CKANUser" as the persona
-        When I log in
-        And I go to data request "Test Request" comments
         And I press the element with xpath "//a[contains(string(), 'Report')]"
         Then I should see "Reported" within 5 seconds
         When I wait for 3 seconds
@@ -99,14 +60,6 @@ Feature: Comments
         Then I go to dataset "warandpeace" comments
         Then I take a screenshot
         And I press the element with xpath "//a[contains(@href, '/delete')]"
-        Then I should see "This comment was deleted." within 2 seconds
-
-    @comment-delete @datarequest
-    Scenario: When an Org Admin visits a data request belonging to their organisation, they can delete a comment and should not see text 'This comment was deleted.'
-        Given "TestOrgAdmin" as the persona
-        When I log in
-        And I go to data request "Test Request" comments
-        And I press the element with xpath "//a[contains(@href, '/delete')]/i[contains(@class, 'icon-remove')]"
         Then I should see "This comment was deleted." within 2 seconds
 
     @comment-tab

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -46,21 +46,6 @@ PERSONAS = {
         'name': u'test_org_member',
         'email': u'test_org_member@localhost',
         'password': u'Password123!'
-    },
-    'DataRequestOrgAdmin': {
-        'name': u'dr_admin',
-        'email': u'dr_admin@localhost',
-        'password': u'Password123!'
-    },
-    'DataRequestOrgEditor': {
-        'name': u'dr_editor',
-        'email': u'dr_editor@localhost',
-        'password': u'Password123!'
-    },
-    'DataRequestOrgMember': {
-        'name': u'dr_member',
-        'email': u'dr_member@localhost',
-        'password': u'Password123!'
     }
 }
 

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -134,7 +134,7 @@ def submit_reply_with_comment(context, comment):
 
 
 # The default behaving step does not convert base64 emails
-# Modifed the default step to decode the payload from base64
+# Modified the default step to decode the payload from base64
 @step(u'I should receive a base64 email at "{address}" containing "{text}"')
 def should_receive_base64_email_containing_text(context, address, text):
     def filter_contents(mail):

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -86,28 +86,6 @@ def go_to_register_page(context):
     when_i_visit_url(context, '/user/register')
 
 
-@step('I go to the data requests page')
-def go_to_data_requests_page(context):
-    when_i_visit_url(context, '/datarequest')
-
-
-@step(u'I go to data request "{subject}"')
-def go_to_data_request(context, subject):
-    context.execute_steps(u"""
-        When I go to the data requests page
-        And I click the link with text "%s"
-        Then I should see "%s" within 5 seconds
-    """ % (subject, subject))
-
-
-@step(u'I go to data request "{subject}" comments')
-def go_to_data_request_comments(context, subject):
-    context.execute_steps(u"""
-        When I go to data request "%s"
-        And I click the link with text that contains "Comments"
-    """ % (subject))
-
-
 @step(u'I set persona var "{key}" to "{value}"')
 def set_persona_var(context, key, value):
     context.persona[key] = value

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -128,12 +128,12 @@ def submit_comment_with_subject_and_comment(context, subject, comment):
         if (subject_field) { subject_field.value = '%s'; }
         """ % subject)
     context.browser.execute_script("""
-        document.querySelector('form#comment-add textarea[name="comment"]').value = '%s';
+        form = document.querySelector('form#comment-add')
+        if (!form) { form = document.querySelector('form#comment_form') }
+        if (!form) { form = document.querySelector('form.dataset-form') }
+        form.querySelector('textarea[name="comment"]').value = '%s';
+        form.querySelector('.btn-primary[type="submit"]').click();
         """ % comment)
-    context.execute_steps(u'Then I take a screenshot')
-    context.browser.execute_script("""
-        document.querySelector('form#comment-add .btn-primary[type="submit"]').click();
-        """)
 
 
 @step(u'I submit a reply with comment "{comment}"')

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -64,8 +64,7 @@ def go_to_dataset_comments(context, name):
 @step(u'I should see the add comment form')
 def comment_form_visible(context):
     context.execute_steps(u"""
-        Then I should see an element with xpath "//input[@name='subject']"
-        And I should see an element with xpath "//textarea[@name='comment']"
+        Then I should see an element with xpath "//textarea[@name='comment']"
     """)
 
 


### PR DESCRIPTION
In the absence of a specific theme, comments on data requests are handled directly by ckanext-data-requests, not by ckanext-ytp-comments.