### PR TITLE
QOL-9055 clean up imports

### DIFF
--- a/ckanext/ytp/comments/email_notifications.py
+++ b/ckanext/ytp/comments/email_notifications.py
@@ -4,9 +4,9 @@ import logging
 
 from ckan import authz, model
 from ckan.lib import maintain
-from ckan.lib.mailer import MailerException
+from ckan.lib.mailer import mail_recipient, MailerException
 from ckan.plugins.toolkit import asbool, config, enqueue_job, get_action, \
-    get_or_bust, mail_recipient, render, url_for, ObjectNotFound
+    get_or_bust, render, url_for, ObjectNotFound
 
 from . import notification_helpers, util
 

--- a/ckanext/ytp/comments/logic/action/get.py
+++ b/ckanext/ytp/comments/logic/action/get.py
@@ -2,9 +2,9 @@
 
 import logging
 
+from ckan.plugins.toolkit import abort, check_access, get_or_bust
+
 import ckanext.ytp.comments.model as comment_model
-from ckan.lib.base import abort
-from ckan import logic
 
 log = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ def thread_show(context, data_dict):
         return abort(404)
 
     data_dict['thread'] = thread
-    # logic.check_access("thread_show", context, data_dict)
+    # check_access("thread_show", context, data_dict)
 
     # Dictize the thread and all the comments within it.
     thread_dict = thread.as_dict()
@@ -73,11 +73,11 @@ def thread_show(context, data_dict):
 
 
 def comment_show(context, data_dict):
-    id = logic.get_or_bust(data_dict, 'id')
+    id = get_or_bust(data_dict, 'id')
     comment = comment_model.Comment.get(id)
     if not comment:
         abort(404)
-    logic.check_access("comment_show", context, data_dict)
+    check_access("comment_show", context, data_dict)
     data_dict['comment'] = comment
 
     return comment.as_dict()
@@ -86,7 +86,7 @@ def comment_show(context, data_dict):
 def comment_count(context, data_dict):
 
     # For now everybody is allowed to view count
-    # logic.check_access('comment_count', context, data_dict)
+    # check_access('comment_count', context, data_dict)
     url = data_dict.get('url')
     id = data_dict.get('id')
     count = None

--- a/ckanext/ytp/comments/logic/action/update.py
+++ b/ckanext/ytp/comments/logic/action/update.py
@@ -1,10 +1,13 @@
+# encoding: utf-8
+
 import datetime
-import ckan.plugins.toolkit as toolkit
+import logging
+
+from ckan.plugins.toolkit import abort, asbool, check_access, config, get_or_bust, \
+    ValidationError
+
 import ckanext.ytp.comments.model as comment_model
 import ckanext.ytp.comments.util as util
-from ckan import logic
-from ckan.lib.base import abort
-import logging
 
 from ckan.common import config
 from ckanext.ytp.comments import helpers
@@ -15,24 +18,24 @@ log = logging.getLogger(__name__)
 def comment_update(context, data_dict):
     model = context['model']
 
-    logic.check_access("comment_update", context, data_dict)
+    check_access("comment_update", context, data_dict)
 
-    cid = logic.get_or_bust(data_dict, 'id')
+    cid = get_or_bust(data_dict, 'id')
     comment = comment_model.Comment.get(cid)
     if not comment:
         abort(404)
 
     # Validate that we have the required fields.
     if not all([data_dict.get('comment')]):
-        raise logic.ValidationError("Comment text is required")
+        raise ValidationError("Comment text is required")
 
     # Cleanup the comment
     cleaned_comment = util.clean_input(data_dict.get('comment'))
 
     # Run profanity check
-    if toolkit.asbool(config.get('ckan.comments.check_for_profanity', False)) \
+    if asbool(config.get('ckan.comments.check_for_profanity', False)) \
             and (helpers.profanity_check(cleaned_comment) or helpers.profanity_check(data_dict.get('subject', ''))):
-        raise logic.ValidationError("Comment blocked due to profanity.")
+        raise ValidationError("Comment blocked due to profanity.")
 
     comment.subject = data_dict.get('subject')
     comment.comment = cleaned_comment

--- a/ckanext/ytp/comments/logic/action/update.py
+++ b/ckanext/ytp/comments/logic/action/update.py
@@ -9,7 +9,6 @@ from ckan.plugins.toolkit import abort, asbool, check_access, config, get_or_bus
 import ckanext.ytp.comments.model as comment_model
 import ckanext.ytp.comments.util as util
 
-from ckan.common import config
 from ckanext.ytp.comments import helpers
 
 log = logging.getLogger(__name__)

--- a/ckanext/ytp/comments/logic/auth/delete.py
+++ b/ckanext/ytp/comments/logic/auth/delete.py
@@ -1,11 +1,10 @@
+# encoding: utf-8
+
 import logging
-from pylons.i18n import _
 
-import ckan.authz as authz
-from ckan import logic
-import ckanext.ytp.comments.model as comment_model
+from ckan.plugins.toolkit import _, get_or_bust
 
-from ckanext.ytp.comments import helpers
+from ckanext.ytp.comments import helpers, model as comment_model
 
 
 log = logging.getLogger(__name__)
@@ -17,10 +16,10 @@ def comment_delete(context, data_dict):
 
     userobj = model.User.get(user)
     # If sysadmin.
-    if authz.is_sysadmin(user):
+    if userobj and userobj.sysadmin:
         return {'success': True}
 
-    cid = logic.get_or_bust(data_dict, 'id')
+    cid = get_or_bust(data_dict, 'id')
 
     comment = comment_model.Comment.get(cid)
     if not comment:

--- a/ckanext/ytp/comments/logic/auth/update.py
+++ b/ckanext/ytp/comments/logic/auth/update.py
@@ -1,9 +1,10 @@
-import logging
-from ckan.common import _
-from ckan import logic
-import ckanext.ytp.comments.model as comment_model
+# encoding: utf-8
 
-from ckanext.ytp.comments import helpers
+import logging
+
+from ckan.plugins.toolkit import _, get_or_bust
+
+from ckanext.ytp.comments import helpers, model as comment_model
 
 log = logging.getLogger(__name__)
 
@@ -18,7 +19,7 @@ def comment_update(context, data_dict):
         log.debug("User is not logged in")
         return {'success': False, 'msg': _('You must be logged in to add a comment')}
 
-    cid = logic.get_or_bust(data_dict, 'id')
+    cid = get_or_bust(data_dict, 'id')
 
     comment = comment_model.Comment.get(cid)
     if not comment:

--- a/ckanext/ytp/comments/model.py
+++ b/ckanext/ytp/comments/model.py
@@ -3,6 +3,7 @@
 import datetime
 import six
 import uuid
+import six.moves.urllib.parse urlparse as urlparse
 
 from sqlalchemy import Column, MetaData, ForeignKey, func
 from sqlalchemy import types
@@ -10,7 +11,7 @@ from sqlalchemy.orm import relationship, backref
 from sqlalchemy.ext.declarative import declarative_base
 
 from ckan.plugins import toolkit
-from ckan.lib.base import model, config
+from ckan.lib.base import model
 
 log = __import__('logging').getLogger(__name__)
 
@@ -51,7 +52,6 @@ class CommentThread(Base):
         We are only interested in the path, so we will strip out
         everything else
         """
-        from urlparse import urlparse
         parsed = urlparse(incoming)
 
         # Perhaps check on acceptable_comment_on()?
@@ -211,13 +211,12 @@ class Comment(Base):
             setattr(self, k, v)
 
         # Auto-set some values based on configuration
-        from pylons import config
-        if toolkit.asbool(config.get('ckan.comments.moderation', 'true')):
+        if toolkit.asbool(toolkit.config.get('ckan.comments.moderation', 'true')):
             self.approval_status = COMMENT_PENDING
         else:
             # If user wants first comment moderated and the user who wrote this hasn't
             # got another comment, put it into moderation, otherwise approve
-            if toolkit.asbool(config.get('ckan.comments.moderation.first_only', 'true')) and \
+            if toolkit.asbool(toolkit.config.get('ckan.comments.moderation.first_only', 'true')) and \
                     Comment.count_for_user(self.user, COMMENT_APPROVED) == 0:
                 self.approval_status = COMMENT_PENDING
             else:
@@ -239,7 +238,7 @@ class Comment(Base):
             user_state = self.comment_user.state
 
         # Hack
-        if name == config.get('ckan.site_id', 'ckan_site_user') or not name:
+        if name == toolkit.config.get('ckan.site_id', 'ckan_site_user') or not name:
             name = 'anonymous'
 
         d = {}

--- a/ckanext/ytp/comments/model.py
+++ b/ckanext/ytp/comments/model.py
@@ -3,7 +3,7 @@
 import datetime
 import six
 import uuid
-import six.moves.urllib.parse as urlparse
+from six.moves.urllib.parse import urlparse
 
 from sqlalchemy import Column, MetaData, ForeignKey, func
 from sqlalchemy import types

--- a/ckanext/ytp/comments/model.py
+++ b/ckanext/ytp/comments/model.py
@@ -3,7 +3,7 @@
 import datetime
 import six
 import uuid
-import six.moves.urllib.parse urlparse as urlparse
+import six.moves.urllib.parse as urlparse
 
 from sqlalchemy import Column, MetaData, ForeignKey, func
 from sqlalchemy import types

--- a/ckanext/ytp/comments/notification_helpers.py
+++ b/ckanext/ytp/comments/notification_helpers.py
@@ -1,10 +1,13 @@
-import ckan.model as model
+# encoding: utf-8
+
 import logging
 import sqlalchemy
 
-from ckan.common import config
-from model import Comment, CommentThread
-from notification_models import CommentNotificationRecipient
+from ckan import model
+from ckan.plugins.toolkit import config
+
+from .model import Comment, CommentThread
+from .notification_models import CommentNotificationRecipient
 
 _and_ = sqlalchemy.and_
 log = logging.getLogger(__name__)

--- a/ckanext/ytp/comments/util.py
+++ b/ckanext/ytp/comments/util.py
@@ -1,7 +1,10 @@
+# encoding: utf-8
+
+import logging
 from lxml.html.clean import Cleaner, autolink_html
 from lxml.html import fromstring
-from ckan import logic
-import logging
+
+from ckan.plugins.toolkit import ValidationError
 
 log = logging.getLogger(__name__)
 
@@ -23,7 +26,7 @@ def clean_input(comment):
         return content
     except Exception as e:
         if type(e).__name__ == "ParserError":
-            raise logic.ValidationError("Comment text is required")
+            raise ValidationError("Comment text is required")
         else:
             template = "An exception of type {0} occurred. Arguments:\n{1!r}"
             message = template.format(type(e).__name__, e.args)
@@ -36,7 +39,7 @@ def remove_HTML_markup(text):
         return fromstring(text.replace('<br/>', '\n')).text_content()
     except Exception as e:
         if type(e).__name__ == "ParserError":
-            raise logic.ValidationError("Text is required")
+            raise ValidationError("Text is required")
         else:
             template = "An exception of type {0} occurred. Arguments:\n{1!r}"
             message = template.format(type(e).__name__, e.args)


### PR DESCRIPTION
- Explicitly mark relative imports to prepare for Python 3
- Use 'six' to handle Py2 to Py3 compatibility
- Make better use of CKAN toolkit API