### PR TITLE
[DC-32866] update route names to handle CKAN 2.9

### DIFF
--- a/ckanext/ytp/comments/controllers/__init__.py
+++ b/ckanext/ytp/comments/controllers/__init__.py
@@ -310,10 +310,10 @@ def unflag(content_type, content_item_id, comment_id):
     return helpers.render_content_template(content_type)
 
 
-def dataset_comments(dataset_id):
+def dataset_comments(id):
     context = {'model': model, 'user': c.user}
 
-    data_dict = {'id': dataset_id}
+    data_dict = {'id': id}
     content_type = 'dataset'
     # Auth check to make sure the user can see this content item
     helpers.check_content_access(content_type, context, data_dict)

--- a/ckanext/ytp/comments/controllers/blueprints.py
+++ b/ckanext/ytp/comments/controllers/blueprints.py
@@ -13,7 +13,7 @@ commenting = Blueprint(
 )
 
 if helpers.show_comments_tab_page():
-    commenting.add_url_rule('/dataset/<dataset_id>/comments', 'list', view_func=dataset_comments)
+    commenting.add_url_rule('/dataset/<id>/comments', 'list', view_func=dataset_comments)
 commenting.add_url_rule('/<dataset_id>/comments/add', view_func=add, methods=('GET', 'POST'))
 commenting.add_url_rule('/<content_type>/<dataset_id>/comments/add', view_func=add, methods=('GET', 'POST'))
 commenting.add_url_rule('/<content_item_id>/comments/<comment_id>/edit', view_func=edit, methods=('GET', 'POST'))

--- a/ckanext/ytp/comments/controllers/pylons_controllers.py
+++ b/ckanext/ytp/comments/controllers/pylons_controllers.py
@@ -26,8 +26,8 @@ class CommentController(BaseController):
     def unflag(self, content_type, content_item_id, comment_id):
         return unflag(content_type, content_item_id, comment_id)
 
-    def dataset_comments(self, dataset_id):
-        return dataset_comments(dataset_id)
+    def dataset_comments(self, id):
+        return dataset_comments(id)
 
 
 class NotificationController(BaseController):

--- a/ckanext/ytp/comments/email_notifications.py
+++ b/ckanext/ytp/comments/email_notifications.py
@@ -8,7 +8,7 @@ from ckan.lib.mailer import mail_recipient, MailerException
 from ckan.plugins.toolkit import asbool, config, enqueue_job, get_action, \
     get_or_bust, render, url_for, ObjectNotFound
 
-from . import notification_helpers, util
+from . import helpers, notification_helpers, util
 
 
 log1 = logging.getLogger(__name__)
@@ -227,14 +227,16 @@ def get_content_item_link(content_type, content_item_id, comment_id=None):
     :param comment_id: string `comment`.`id`
     :return:
     """
-    # Default to the dataset route as this is the way `ckanext-ytp-comments` always worked
-    url = url_for('dataset_read', id=content_item_id, qualified=True)
     if content_type == 'datarequest':
-        url = url_for('comment_datarequest', id=content_item_id, qualified=True)
+        route_name = 'datarequest.comment' \
+            if helpers.is_ckan_29() else 'comment_datarequest'
     elif asbool(config.get('ckan.comments.show_comments_tab_page', False)):
-        # Not sure why `url_for` won't recognise "dataset_comments" as a named route, even though it is named in
-        # the plugins.py "before_map" function as such, so we do this:
-        url += '/comments'
+        route_name = 'comments.list' \
+            if helpers.is_ckan_29() else 'dataset_comments'
+    else:
+        route_name = 'dataset.read' \
+            if helpers.is_ckan_29() else 'dataset_read'
+    url = url_for(route_name, id=content_item_id, qualified=True)
     if comment_id:
         url += '#comment_' + str(comment_id)
     return url

--- a/ckanext/ytp/comments/plugin_mixins/pylons_plugin.py
+++ b/ckanext/ytp/comments/plugin_mixins/pylons_plugin.py
@@ -17,8 +17,8 @@ class MixinPlugin(p.SingletonPlugin):
         """
         controller = 'ckanext.ytp.comments.controllers.pylons_controllers:CommentController'
         if helpers.show_comments_tab_page():
-            map.connect('comments.list', '/dataset/{dataset_id}/comments', controller=controller, action='dataset_comments', ckan_icon='comment')
-            map.connect('dataset_comments', '/dataset/{dataset_id}/comments', controller=controller, action='dataset_comments', ckan_icon='comment')
+            map.connect('comments.list', '/dataset/{id}/comments', controller=controller, action='dataset_comments', ckan_icon='comment')
+            map.connect('dataset_comments', '/dataset/{id}/comments', controller=controller, action='dataset_comments', ckan_icon='comment')
         map.connect('/{dataset_id}/comments/add', controller=controller, action='add')
         map.connect('/{content_type}/{dataset_id}/comments/add', controller=controller, action='add')
         map.connect('/{content_item_id}/comments/{comment_id}/edit', controller=controller, action='edit')

--- a/ckanext/ytp/comments/templates/package/read_base.html
+++ b/ckanext/ytp/comments/templates/package/read_base.html
@@ -3,6 +3,6 @@
 {% block content_primary_nav %}
     {{ super() }}
     {% if h.ytp_comments_show_comments_tab_page() %}
-        {{ h.build_nav_icon('comments.list', _('Comments') + ' ' + h.get_content_type_comments_badge(pkg.name, 'dataset'), dataset_id=pkg.name) }}
+        {{ h.build_nav_icon('comments.list', _('Comments') + ' ' + h.get_content_type_comments_badge(pkg.name, 'dataset'), id=pkg.name) }}
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
- Also fix route parameter name to always be 'id' so we can use url_for consistently