### PR TITLE
QOLSVC-978 ckan 2.10 compatibility

### DIFF
--- a/.docker/Dockerfile-template.ckan
+++ b/.docker/Dockerfile-template.ckan
@@ -12,7 +12,8 @@ RUN apk add --no-cache build-base \
     && curl -sL https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/dockerize-alpine-linux-amd64-${DOCKERIZE_VERSION}.tar.gz \
         | tar -C /usr/local/bin -xzvf -
 
-# Install CKAN.
+# Update urllib3 to fix urlopen bug
+RUN pip install -U urllib3
 
 COPY .docker/test.ini $CKAN_INI
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,12 @@ jobs:
 
     name: Test on CKAN ${{ matrix.ckan-version }}
     runs-on: ubuntu-latest
-    container: integratedexperts/ci-builder
+    container: drevops/ci-builder
     env:
       CKAN_VERSION: ${{ matrix.ckan-version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         timeout-minutes: 2
 
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ckan-version: [2.9, 2.9-py2, 2.8]
+        ckan-version: ["2.10", 2.9, 2.9-py2]
 
     name: Test on CKAN ${{ matrix.ckan-version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ckan-version: ["2.10", 2.9, 2.9-py2]
+        ckan-version: [2.9, 2.9-py2, 2.8]
 
     name: Test on CKAN ${{ matrix.ckan-version }}
     runs-on: ubuntu-latest

--- a/bin/serve.sh
+++ b/bin/serve.sh
@@ -5,7 +5,7 @@ dockerize -wait tcp://postgres:5432 -timeout 1m
 dockerize -wait tcp://solr:8983 -timeout 1m
 dockerize -wait tcp://redis:6379 -timeout 1m
 
-for i in {1..60}; do
+for i in `seq 1 60`; do
     if (PGPASSWORD=pass psql -h postgres -U ckan_default -d ckan_test -c "\q"); then
         break
     else

--- a/ckanext/ytp/comments/cli/command.py
+++ b/ckanext/ytp/comments/cli/command.py
@@ -37,7 +37,8 @@ def updatedb():
     log.info("YTP-Comments-UpdateDBCommand: Starting command")
 
     from sqlalchemy import MetaData, DDL
-    meta = MetaData(bind=model.Session.get_bind(), reflect=True)
+    meta = MetaData()
+    meta.reflect(bind=model.Session.get_bind())
 
     if 'comment' in meta.tables and 'deleted_by_user_id' not in meta.tables['comment'].columns:
         log.info("YTP-Comments-UpdateDBCommand: 'deleted_by_user_id' field does not exist, adding...")

--- a/ckanext/ytp/comments/model.py
+++ b/ckanext/ytp/comments/model.py
@@ -10,8 +10,8 @@ from sqlalchemy import types
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy.ext.declarative import declarative_base
 
+from ckan import model
 from ckan.plugins import toolkit
-from ckan.lib.base import model
 
 log = __import__('logging').getLogger(__name__)
 

--- a/test/features/steps/steps.py
+++ b/test/features/steps/steps.py
@@ -99,6 +99,8 @@ def should_receive_base64_email_containing_texts(context, address, text, text2):
     assert context.mail.user_messages(address, filter_contents)
 
 
+# ckanext-ytp-comments
+
 @step(u'I go to dataset "{name}" comments')
 def go_to_dataset_comments(context, name):
     context.execute_steps(u"""


### PR DESCRIPTION
- Import 'model' from stable location
- Replace deprecated SQLAlchemy 'reflect' syntax
- Replace obsolete test container with 'drevops'