### PR TITLE
QOLSVC-978 CKAN 2.10 testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ckan-version: [2.9, 2.9-py2, 2.8]
+        ckan-version: ["2.10", 2.9, 2.9-py2, 2.8]
 
     name: Test on CKAN ${{ matrix.ckan-version }}
     runs-on: ubuntu-latest

--- a/bin/create-test-data.sh
+++ b/bin/create-test-data.sh
@@ -68,30 +68,10 @@ curl -LsH "Authorization: ${API_KEY}" \
 # END.
 #
 
-# Creating test data hierarchy which creates organisations assigned to datasets
-ckan_cli create-test-data hierarchy
-
 # Creating basic test data which has datasets with resources
-ckan_cli create-test-data basic
-
-# Datasets need to be assigned to an organisation
-
-echo "Assigning test Datasets to Organisation..."
-
-echo "Updating annakarenina to use ${TEST_ORG_TITLE} organisation:"
-package_owner_org_update=$( \
-    curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"id": "annakarenina", "organization_id": "'"${TEST_ORG_NAME}"'"}' \
-    ${CKAN_ACTION_URL}/package_owner_org_update
-)
-echo ${package_owner_org_update}
-
-echo "Updating warandpeace to use ${TEST_ORG_TITLE} organisation:"
-package_owner_org_update=$( \
-    curl -LsH "Authorization: ${API_KEY}" \
-    --data '{"id": "warandpeace", "organization_id": "'"${TEST_ORG_NAME}"'"}' \
-    ${CKAN_ACTION_URL}/package_owner_org_update
-)
-echo ${package_owner_org_update}
+curl -LsH "Authorization: ${API_KEY}" \
+    --data '{"name": "warandpeace", "owner_org": "'"${TEST_ORG_ID}"'",
+"author_email": "admin@localhost", "license_id": "other-open", "notes": "test"}' \
+    ${CKAN_ACTION_URL}/package_create
 
 . ${APP_DIR}/bin/deactivate


### PR DESCRIPTION
- Create test data via API (which is more stable) instead of CLI
- Add CKAN 2.10 testing to GitHub Actions workflow