### PR TITLE
QOLDEV-683 revert profanityfilter entry point

### DIFF
--- a/ckanext/ytp/comments/helpers.py
+++ b/ckanext/ytp/comments/helpers.py
@@ -6,7 +6,7 @@ import sqlalchemy
 from ckan import model
 from ckan.plugins.toolkit import asbool, c, h, config, check_access, \
     check_ckan_version, get_action, render, render_snippet, url_for
-from profanityfilter.profanityfilter import ProfanityFilter
+from profanityfilter import ProfanityFilter
 
 _and_ = sqlalchemy.and_
 log = logging.getLogger(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 lxml==4.9.1
 
--e git+https://github.com/qld-gov-au/profanityfilter.git@2.0.6-qgov.1#egg=profanityfilter
+-e git+https://github.com/qld-gov-au/profanityfilter.git@2.0.6-qgov.2#egg=profanityfilter


### PR DESCRIPTION
Entry point was changed because Flake8 complained of an unused import, but it's better to add a Flake8 ignore than change it.