### PR TITLE
revert requirement change

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,5 +9,3 @@ flake8==3.8.3
 mock
 pytest-ckan
 splinter>=0.13.0,<0.17
-
-git+https://github.com/qld-gov-au/profanityfilter.git@2.0.6-qgov.3#egg=profanityfilter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 lxml==4.9.1
-
-profanityfilter
+git+https://github.com/qld-gov-au/profanityfilter.git@2.0.6-qgov.3#egg=profanityfilter


### PR DESCRIPTION
- profanityfilter is not a plugin, it doesn't have the same potential clashes and won't be installed if we don't do it here