### PR TITLE
[QOLDEV-833] restore editable flag on profanityfilter installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 lxml==4.9.1
-git+https://github.com/qld-gov-au/profanityfilter.git@2.0.6-qgov.3#egg=profanityfilter
+-e git+https://github.com/qld-gov-au/profanityfilter.git@2.0.6-qgov.3#egg=profanityfilter


### PR DESCRIPTION
- This lets us sidestep pip versioning and rely on our Git tagging instead